### PR TITLE
Put try, except around OAuth2Token __init__

### DIFF
--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -27,7 +27,11 @@ class OAuth2Token(dict):
 
     def __init__(self, params, old_scope=None):
         super(OAuth2Token, self).__init__(params)
-        self._new_scope = set(utils.scope_to_list(params.get('scope', '')))
+        #Try catch if scope is NoneType
+        try:
+            self._new_scope = set(utils.scope_to_list(params.get('scope', '')))
+        except TypeError:
+            self._new_scope = ''
         if old_scope is not None:
             self._old_scope = set(utils.scope_to_list(old_scope))
         else:


### PR DESCRIPTION
Put try, except around OAuth2Token.__init__ so NoneType scopes don't raise errors.

Fix for issue #296