### PR TITLE
Revocation endpoint should return empty string, not Python 'None'

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -74,7 +74,7 @@ class RevocationEndpoint(BaseEndpoint):
         self.request_validator.revoke_token(request.token,
                                             request.token_type_hint, request)
 
-        response_body = None
+        response_body = ''
         if self.enable_jsonp and request.callback:
             response_body = request.callback + '();'
         return {}, response_body, 200

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -30,7 +30,7 @@ class RevocationEndpointTest(TestCase):
             h, b, s = self.endpoint.create_revocation_response(self.uri,
                     headers=self.headers, body=body)
             self.assertEqual(h, {})
-            self.assertEqual(b, None)
+            self.assertEqual(b, '')
             self.assertEqual(s, 200)
 
     def test_revoke_with_callback(self):


### PR DESCRIPTION
References https://github.com/evonove/django-oauth-toolkit/issues/158