### PR TITLE
Lock requirements to specific versions. Use requirements.txt for tox dep...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,20 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
-  - pip install nose pycrypto mock pyjwt blinker
+  - pip install tox coveralls
 
 script:
-  - nosetests -w tests
+  - tox
 
-after_success:
-  - pip install coveralls
-  - coverage run --source=oauthlib setup.py -q nosetests
-  - coveralls
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py32
+  - TOXENV=pypy
+
+after_success: coveralls
 
 branches:
   only:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+coverage==3.7.1
+nose==1.3.4
+mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-docutils
-python-creole
--e git+https://github.com/ternstor/pycco.git#egg=pycco
-pycrypto
-mock
-nose
-sphinx
-pyjwt
+nose==1.3.4
+mock==1.0.1
+pycrypto==2.6.1
+pyjwt==0.3.2
+blinker==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-nose==1.3.4
-mock==1.0.1
 pycrypto==2.6.1
 pyjwt==0.3.2
 blinker==1.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 envlist = py26,py27,py32,py33,py34,pypy
 
 [testenv]
-deps=-rrequirements.txt
-commands=nosetests -w tests
+deps=
+    -rrequirements-test.txt
+commands=nosetests --with-coverage --cover-erase --cover-package=oauthlib -w tests
 
 [testenv:py26]
 deps=unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,7 @@
 envlist = py26,py27,py32,py33,py34,pypy
 
 [testenv]
-deps=nose
-     pycrypto
-     mock
-     pyjwt
-     blinker
+deps=-rrequirements.txt
 commands=nosetests -w tests
 
 [testenv:py26]


### PR DESCRIPTION
Builds are failing because unversioned dependencies are no longer compatible. pyjwt 0.4.1 was being installed and we need to update to support this version. This PR locks dependencies to the most recent working versions. 