### PR TITLE
Check for rsa_key when it's actually needed

### DIFF
--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -101,10 +101,6 @@ class Client(object):
         self.nonce = encode(nonce)
         self.timestamp = encode(timestamp)
 
-        if self.signature_method == SIGNATURE_RSA and self.rsa_key is None:
-            raise ValueError(
-                'rsa_key is required when using RSA signature method.')
-
     def __repr__(self):
         attrs = vars(self).copy()
         attrs['client_secret'] = '****' if attrs['client_secret'] else None

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -500,6 +500,8 @@ def sign_rsa_sha1(base_string, rsa_private_key):
 
 
 def sign_rsa_sha1_with_client(base_string, client):
+    if not client.rsa_key:
+        raise ValueError('rsa_key is required when using RSA signature method.')
     return sign_rsa_sha1(base_string, client.rsa_key)
 
 

--- a/tests/oauth1/rfc5849/test_client.py
+++ b/tests/oauth1/rfc5849/test_client.py
@@ -61,6 +61,10 @@ class ClientConstructorTests(TestCase):
             self.assertIsInstance(k, bytes_type)
             self.assertIsInstance(v, bytes_type)
 
+    def test_rsa(self):
+        client = Client('client_key', signature_method=SIGNATURE_RSA)
+        self.assertIsNone(client.rsa_key)  # don't need an RSA key to instantiate
+
 
 class SignatureMethodTest(TestCase):
 
@@ -96,7 +100,6 @@ class SignatureMethodTest(TestCase):
                    'HJILzZ8iFOvS6w5E%3D"')
         self.assertEqual(h['Authorization'], correct)
 
-
     def test_plaintext_method(self):
         client = Client('client_key',
                         signature_method=SIGNATURE_PLAINTEXT,
@@ -115,6 +118,9 @@ class SignatureMethodTest(TestCase):
         client = Client('client_key', signature_method='invalid')
         self.assertRaises(ValueError, client.sign, 'http://example.com')
 
+    def test_rsa_no_key(self):
+        client = Client('client_key', signature_method=SIGNATURE_RSA)
+        self.assertRaises(ValueError, client.sign, 'http://example.com')
 
     def test_register_method(self):
         Client.register_signature_method('PIZZA',


### PR DESCRIPTION
We might want to instantiate a RSA OAuth1 client, but not load the RSA key until later. We should move the check from where the client is initialized, to where the RSA key is actually used.