### PR TITLE
WIP: switch from PyCrypto to cryptography library

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -229,10 +229,13 @@ def generate_token(length=30, chars=UNICODE_ASCII_CHARACTER_SET):
 
 
 def generate_signed_token(private_pem, request):
-    import Crypto.PublicKey.RSA as RSA
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.backends import default_backend
     import jwt
 
-    private_key = RSA.importKey(private_pem)
+    private_key = serialization.load_pem_private_key(
+        private_pem.encode('utf-8'), password=None, backend=default_backend(),
+    )
 
     now = datetime.datetime.utcnow()
 
@@ -250,10 +253,14 @@ def generate_signed_token(private_pem, request):
 
 
 def verify_signed_token(private_pem, token):
-    import Crypto.PublicKey.RSA as RSA
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.backends import default_backend
     import jwt
 
-    public_key = RSA.importKey(private_pem).publickey()
+    private_key = serialization.load_pem_private_key(
+        private_pem.encode('utf-8'), password=None, backend=default_backend(),
+    )
+    public_key = private_key.public_key()
 
     try:
         # return jwt.verify_jwt(token.encode(), public_key)

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -484,15 +484,23 @@ def sign_rsa_sha1(base_string, rsa_private_key):
 
     """
     # TODO: finish RSA documentation
-    from Crypto.PublicKey import RSA
-    from Crypto.Signature import PKCS1_v1_5
-    from Crypto.Hash import SHA
-    key = RSA.importKey(rsa_private_key)
-    if isinstance(base_string, unicode_type):
-        base_string = base_string.encode('utf-8')
-    h = SHA.new(base_string)
-    p = PKCS1_v1_5.new(key)
-    return binascii.b2a_base64(p.sign(h))[:-1].decode('utf-8')
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding
+    from cryptography.hazmat.backends import default_backend
+    private_key = serialization.load_pem_private_key(
+        rsa_private_key.encode('utf-8'), password=None, backend=default_backend(),
+    )
+    signer = private_key.signer(
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.MAX_LENGTH
+        ),
+        hashes.SHA256()
+    )
+    signer.update(base_string)
+    signature = signer.finalize()
+    return binascii.b2a_base64(signature)
 
 
 def sign_rsa_sha1_with_client(base_string, client):
@@ -568,7 +576,7 @@ def verify_rsa_sha1(request, rsa_public_key):
 
     Per `section 3.4.3`_ of the spec.
 
-    Note this method requires the PyCrypto library.
+    Note this method requires the cryptography library.
 
     .. _`section 3.4.3`: http://tools.ietf.org/html/rfc5849#section-3.4.3
 
@@ -580,17 +588,27 @@ def verify_rsa_sha1(request, rsa_public_key):
 
     .. _`RFC2616 section 5.2`: http://tools.ietf.org/html/rfc2616#section-5.2
     """
-    from Crypto.PublicKey import RSA
-    from Crypto.Signature import PKCS1_v1_5
-    from Crypto.Hash import SHA
-    key = RSA.importKey(rsa_public_key)
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding
+    from cryptography.hazmat.backends import default_backend
+    public_key = serialization.load_pem_public_key(
+        rsa_public_key.encode('utf-8'), backend=default_backend(),
+    )
     norm_params = normalize_parameters(request.params)
     uri = normalize_base_string_uri(request.uri)
     message = construct_base_string(request.http_method, uri, norm_params)
-    h = SHA.new(message.encode('utf-8'))
-    p = PKCS1_v1_5.new(key)
-    sig = binascii.a2b_base64(request.signature.encode('utf-8'))
-    return p.verify(h, sig)
+    signature = binascii.a2b_base64(request.signature.encode('utf-8'))
+    verifier = public_key.verifier(
+        signature,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.MAX_LENGTH
+        ),
+        hashes.SHA256()
+    )
+    verifier.update(message)
+    return verifier.verify()
 
 
 def verify_plaintext(request, client_secret=None, resource_owner_secret=None):

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ def fread(fn):
         return f.read()
 
 if sys.version_info[0] == 3:
-    tests_require = ['nose', 'pycrypto', 'pyjwt', 'blinker']
+    tests_require = ['nose', 'cryptography', 'pyjwt', 'blinker']
 else:
-    tests_require = ['nose', 'unittest2', 'pycrypto', 'mock', 'pyjwt', 'blinker']
-rsa_require = ['pycrypto']
-signedtoken_require = ['pycrypto', 'pyjwt']
+    tests_require = ['nose', 'unittest2', 'cryptography', 'mock', 'pyjwt', 'blinker']
+rsa_require = ['cryptography']
+signedtoken_require = ['cryptography', 'pyjwt']
 signals_require = ['blinker']
 
 requires = []

--- a/tests/oauth2/rfc6749/test_server.py
+++ b/tests/oauth2/rfc6749/test_server.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 from ...unittest import TestCase
-import Crypto.PublicKey.RSA as RSA
 import json
 import jwt
 import mock


### PR DESCRIPTION
PyJWT is now using the [`cryptography`](https://cryptography.io) library internally, and it looks like it's the future of cryptography in Python. (*Way* more understandable!) This is a WIP pull request that starts ripping out PyCrypto and replacing it with `cryptography`. I'm not sure if I'll have time to continue to work on this, so if others want to step up and do the work necessary to finish this pull request, I'd really appreciate it!