### PR TITLE
Strip whitespace off of scope string. 

### DIFF
--- a/oauthlib/oauth2/rfc6749/utils.py
+++ b/oauthlib/oauth2/rfc6749/utils.py
@@ -41,7 +41,7 @@ def scope_to_list(scope):
     elif scope is None:
         return None
     else:
-        return scope.split(" ")
+        return scope.strip().split(" ")
 
 
 def params_from_uri(uri):

--- a/tests/oauth2/rfc6749/test_utils.py
+++ b/tests/oauth2/rfc6749/test_utils.py
@@ -79,7 +79,7 @@ class UtilsTests(TestCase):
     def test_scope_to_list(self):
         expected = ['foo', 'bar', 'baz']
 
-        string_scopes = 'foo bar baz'
+        string_scopes = 'foo bar baz '
         self.assertEqual(scope_to_list(string_scopes), expected)
 
         string_list_scopes = ['foo', 'bar', 'baz']


### PR DESCRIPTION
This ensures `validate_authorization_request()` will not return empty scopes if there is trailing white space in the scope string.