### PR TITLE
Oauth1 signing: fix error message on invalid Content-Type header

### DIFF
--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -271,7 +271,9 @@ class Client(object):
         #       header field set to "application/x-www-form-urlencoded".
         elif not should_have_params and has_params:
             raise ValueError(
-                "Body contains parameters but Content-Type header was not set.")
+                "Body contains parameters but Content-Type header was {0} "
+                "instead of {1}".format(content_type or "not set",
+                                        CONTENT_TYPE_FORM_URLENCODED))
 
         # 3.5.2.  Form-Encoded Body
         # Protocol parameters can be transmitted in the HTTP request entity-


### PR DESCRIPTION
Content-Type should be application/x-www-form-urlencoded when the
request to sign has a body. If it's not the case a ValueError was raised
saying Content-Type was missing, while it actually could just be wrongly
set (e.g. to application/json). Fix the error message to reflect the
real problem: expected & given Content-Type.

Note that I couldn't run the tests locally: I get multiple errors no matter how I run it: from my virtualenv
```
$ pip install -r requirements.txt
$ nosetests  # 8 errors 4 failures
$ python -m unittest discover # same
$ deactivate; tox  # same for all envs
```
Errors include "Algorithm not supported" for RS256 and "Warning not raised" in invokations of `client.parse_request_body_response()`.