### PR TITLE
Precise oauth1 client workflow in documentation

### DIFF
--- a/docs/oauth1/client.rst
+++ b/docs/oauth1/client.rst
@@ -28,15 +28,16 @@ Using the Client
     the credentials from before when obtaining an access token::
 
         client = oauthlib.oauth1.Client('client_key', client_secret='your_secret',
-            resource_owner_secret='the_new_secret', verifier='the_verifier')
+            resource_owner_key='the_request_token', resource_owner_secret='the_request_token_secret',
+            verifier='the_verifier')
         uri, headers, body = client.sign('http://example.com/access_token')
 
     The provider will now give you an access token and a new token secret which
     you will use to access protected resources::
 
         client = oauthlib.oauth1.Client('client_key', client_secret='your_secret',
-            resource_owner_key='the_access_token', resource_owner_secret='the_token_secret')
-        uri, headers, body = client.sign('http://example.com/access_token')
+            resource_owner_key='the_access_token', resource_owner_secret='the_access_token_secret')
+        uri, headers, body = client.sign('http://example.com/protected_resource')
 
     .. _`requests-oauthlib`: https://github.com/requests/requests-oauthlib
 


### PR DESCRIPTION
If i understand correctly the OAuth 1.0a, https://oauthlib.readthedocs.org/en/latest/oauth1/client.html have some inaccuracies. For example, to obtain access token and access secret we need to provide both request token and request secret, not just request secret.