### PR TITLE
Allow tuples for list_to_scope as well as sets and lists

### DIFF
--- a/oauthlib/oauth2/rfc6749/utils.py
+++ b/oauthlib/oauth2/rfc6749/utils.py
@@ -27,7 +27,7 @@ def list_to_scope(scope):
     elif isinstance(scope, (set, tuple, list)):
         return " ".join([unicode_type(s) for s in scope])
     else:
-        raise ValueError("Invalid scope, must be string or list.")
+        raise ValueError("Invalid scope (%s), must be string, tuple, set, or list." % scope)
 
 
 def scope_to_list(scope):

--- a/oauthlib/oauth2/rfc6749/utils.py
+++ b/oauthlib/oauth2/rfc6749/utils.py
@@ -24,20 +24,16 @@ def list_to_scope(scope):
     """Convert a list of scopes to a space separated string."""
     if isinstance(scope, unicode_type) or scope is None:
         return scope
-    elif isinstance(scope, (tuple, list)):
+    elif isinstance(scope, (set, tuple, list)):
         return " ".join([unicode_type(s) for s in scope])
-    elif isinstance(scope, set):
-        return list_to_scope(list(scope))
     else:
         raise ValueError("Invalid scope, must be string or list.")
 
 
 def scope_to_list(scope):
     """Convert a space separated string to a list of scopes."""
-    if isinstance(scope, list):
+    if isinstance(scope, (tuple, list, set)):
         return [unicode_type(s) for s in scope]
-    if isinstance(scope, set):
-        scope_to_list(list(scope))
     elif scope is None:
         return None
     else:

--- a/tests/oauth2/rfc6749/test_utils.py
+++ b/tests/oauth2/rfc6749/test_utils.py
@@ -85,6 +85,8 @@ class UtilsTests(TestCase):
         for x in string_list:
             assert x in set_scope
 
+        self.assertRaises(ValueError, list_to_scope, object()) 
+
     def test_scope_to_list(self):
         expected = ['foo', 'bar', 'baz']
 

--- a/tests/oauth2/rfc6749/test_utils.py
+++ b/tests/oauth2/rfc6749/test_utils.py
@@ -79,6 +79,12 @@ class UtilsTests(TestCase):
         obj_list = [ScopeObject('foo'), ScopeObject('bar'), ScopeObject('baz')]
         self.assertEqual(list_to_scope(obj_list), expected)
 
+        set_list = set(string_list)
+        set_scope = list_to_scope(set_list)
+        assert len(set_scope.split(' ')) == 3
+        for x in string_list:
+            assert x in set_scope
+
     def test_scope_to_list(self):
         expected = ['foo', 'bar', 'baz']
 
@@ -88,9 +94,15 @@ class UtilsTests(TestCase):
         string_list_scopes = ['foo', 'bar', 'baz']
         self.assertEqual(scope_to_list(string_list_scopes), expected)
 
+        tuple_list_scopes = ('foo', 'bar', 'baz')
+        self.assertEqual(scope_to_list(tuple_list_scopes), expected)
+
         obj_list_scopes = [ScopeObject('foo'), ScopeObject('bar'), ScopeObject('baz')]
         self.assertEqual(scope_to_list(obj_list_scopes), expected)
 
+        set_list_scopes = set(string_list_scopes)
+        set_list = scope_to_list(set_list_scopes)
+        self.assertEqual(sorted(set_list), sorted(string_list_scopes))
 
 
 


### PR DESCRIPTION
This is a really simple change to allow scopes to be specified as a tuple of strings instead of just lists and sets. Test included.