### PR TITLE
Add code to determine if client authentication is required for OAuth2…

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -120,8 +120,9 @@ class RevocationEndpoint(BaseEndpoint):
             raise InvalidRequestError(request=request,
                                       description='Missing token parameter.')
 
-        if not self.request_validator.authenticate_client(request):
-            raise InvalidClientError(request=request)
+        if self.request_validator.client_authentication_required(request):
+            if not self.request_validator.authenticate_client(request):
+                raise InvalidClientError(request=request)
 
         if (request.token_type_hint and
                 request.token_type_hint in self.valid_token_types and

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -32,6 +32,18 @@ class RevocationEndpointTest(TestCase):
             self.assertEqual(h, {})
             self.assertEqual(b, None)
             self.assertEqual(s, 200)
+    
+    def test_revoke_token_without_client_authentication(self):
+        self.validator.client_authentication_required.return_value = False
+        self.validator.authenticate_client.return_value = False        
+        for token_type in ('access_token', 'refresh_token', 'invalid'):
+            body = urlencode([('token', 'foo'),
+                              ('token_type_hint', token_type)])
+            h, b, s = self.endpoint.create_revocation_response(self.uri,
+                    headers=self.headers, body=body)
+            self.assertEqual(h, {})
+            self.assertEqual(b, None)
+            self.assertEqual(s, 200)
 
     def test_revoke_with_callback(self):
         endpoint = RevocationEndpoint(self.validator, enable_jsonp=True)


### PR DESCRIPTION
An attempt to improve OAuth2 endpoint "revocation.py", and to fix django-oauth-toolkit issues https://github.com/evonove/django-oauth-toolkit/issues/244 and https://github.com/evonove/django-oauth-toolkit/issues/242.

The "client authentication" is always required in the current method `validate_revocation_request`. There are cases that the authentication can be ignored though, like when grand type is "Resource Owner Password Credentials" and the "Client type" is Public.

The patch makes this possible so you can just pass a client_id (without secret) to revoke a token.

@ib-lundgren could you please take a look at this one :)