### PR TITLE
#340 - calling getattr on Request should raise an AttributeError if that attribute doesn't exist

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -381,7 +381,15 @@ class Request(object):
         self.decoded_body = extract_params(encode(body))
         self.oauth_params = []
 
-        self._params = {}
+        self._params = {
+            "client_id": None,
+            "grant_type": None,
+            "redirect_uri": None,
+            "response_type": None,
+            "state": None,
+            "refresh_token": None,
+            "access_token": None,
+        }
         self._params.update(dict(urldecode(self.uri_query)))
         self._params.update(dict(self.decoded_body or []))
         self._params.update(self.headers)

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -387,7 +387,10 @@ class Request(object):
         self._params.update(self.headers)
 
     def __getattr__(self, name):
-        return self._params.get(name, None)
+        if name in self._params:
+            return self._params[name]
+        else:
+            raise AttributeError(name)
 
     def __repr__(self):
         return '<oauthlib.Request url="%s", http_method="%s", headers="%s", body="%s">' % (

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -382,13 +382,20 @@ class Request(object):
         self.oauth_params = []
 
         self._params = {
+            "access_token": None,
+            "client": None,
             "client_id": None,
+            "code": None,
+            "extra_credentials": None,
             "grant_type": None,
             "redirect_uri": None,
-            "response_type": None,
-            "state": None,
             "refresh_token": None,
-            "access_token": None,
+            "response_type": None,
+            "scope": None,
+            "scopes": None,
+            "state": None,
+            "token": None,
+            "user": None,
         }
         self._params.update(dict(urldecode(self.uri_query)))
         self._params.update(dict(self.decoded_body or []))

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -380,7 +380,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
             raise errors.InvalidGrantError(request=request)
 
         for attr in ('user', 'state', 'scopes'):
-            if getattr(request, attr) is None:
+            if getattr(request, attr, None) is None:
                 log.debug('request.%s was not set on code validation.', attr)
 
         # REQUIRED, if the "redirect_uri" parameter was included in the

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -23,7 +23,8 @@ class GrantTypeBase(object):
         raise NotImplementedError('Subclasses must implement this method.')
 
     def validate_grant_type(self, request):
-        if not self.request_validator.validate_grant_type(request.client_id,
+        client_id = getattr(request, 'client_id', None)
+        if not self.request_validator.validate_grant_type(client_id,
                                                           request.grant_type, request.client, request):
             log.debug('Unauthorized from %r (%r) access to grant type %s.',
                       request.client_id, request.client, request.grant_type)

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -83,7 +83,7 @@ class ClientCredentialsGrant(GrantTypeBase):
         return headers, json.dumps(token), 200
 
     def validate_token_request(self, request):
-        if not getattr(request, 'grant_type'):
+        if not getattr(request, 'grant_type', None):
             raise errors.InvalidRequestError('Request is missing grant type.',
                                              request=request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -160,7 +160,7 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
         """
         for param in ('grant_type', 'username', 'password'):
-            if not getattr(request, param):
+            if not getattr(request, param, None):
                 raise errors.InvalidRequestError(
                     'Request is missing %s parameter.' % param, request=request)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -171,6 +171,20 @@ class RequestTest(TestCase):
         r = Request(URI, body=PARAMS_DICT)
         self.assertItemsEqual(r.decoded_body, PARAMS_TWOTUPLE)
 
+    def test_getattr_existing_attribute(self):
+        r = Request(URI, body='foo bar')
+        self.assertEqual('foo bar', getattr(r, 'body'))
+
+    def test_getattr_return_default(self):
+        r = Request(URI, body='')
+        actual_value = getattr(r, 'does_not_exist', 'foo bar')
+        self.assertEqual('foo bar', actual_value)
+
+    def test_getattr_raise_attribute_error(self):
+        r = Request(URI, body='foo bar')
+        with self.assertRaises(AttributeError):
+            getattr(r, 'does_not_exist')
+
 
 class CaseInsensitiveDictTest(TestCase):
 


### PR DESCRIPTION
https://github.com/idan/oauthlib/issues/340

Raise an `AttributeError` from `common.Request.__getattr__` so that `getattr` can be used like normal on a request. This commit breaks a lot of existing tests, which I'll fix in another commit.

This might break backwards compatibility if people are relying on `getattr(Request)` automatically returning `None`. 