### PR TITLE
send no state in the access token response

### DIFF
--- a/examples/skeleton_oauth2_web_application_server.py
+++ b/examples/skeleton_oauth2_web_application_server.py
@@ -64,7 +64,7 @@ class SkeletonValidator(RequestValidator):
 
     def validate_code(self, client_id, code, client, request, *args, **kwargs):
         # Validate the code belongs to the client. Add associated scopes,
-        # state and user to request.scopes, request.state and request.user.
+        # state and user to request.scopes and request.user.
         pass
 
     def confirm_redirect_uri(self, client_id, code, redirect_uri, client, *args, **kwargs):

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -383,7 +383,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
                       request.client_id, request.client, request.scopes)
             raise errors.InvalidGrantError(request=request)
 
-        for attr in ('user', 'state', 'scopes'):
+        for attr in ('user', 'scopes'):
             if getattr(request, attr, None) is None:
                 log.debug('request.%s was not set on code validation.', attr)
 

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -342,8 +342,8 @@ class RequestValidator(object):
         """Ensure the authorization_code is valid and assigned to client.
 
         OBS! The request.user attribute should be set to the resource owner
-        associated with this authorization code. Similarly request.scopes and
-        request.state must also be set.
+        associated with this authorization code. Similarly request.scopes
+        must also be set.
 
         :param client_id: Unicode client identifier
         :param code: Unicode authorization code


### PR DESCRIPTION
In the Authorization Code Grant flow, the state parameter is send back to the client in the authorization response.
It is useless to send the state parameter also in the access token response
because the client does a direct HTTP  request.
See https://tools.ietf.org/html/rfc6749#page-30