### PR TITLE
Handle empty/non-parsable query strings

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -308,7 +308,11 @@ class AuthorizationCodeGrant(GrantTypeBase):
             raise errors.InvalidRequestError(description='Missing response_type parameter.', request=request)
 
         for param in ('client_id', 'response_type', 'redirect_uri', 'scope', 'state'):
-            if param in request.duplicate_params:
+            try:
+                duplicate_params = request.duplicate_params
+            except ValueError:
+                raise errors.InvalidRequestError(description='Unable to parse query string', request=request)
+            if param in duplicate_params:
                 raise errors.InvalidRequestError(description='Duplicate %s parameter.' % param, request=request)
 
         if not self.request_validator.validate_response_type(request.client_id,

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -310,7 +310,11 @@ class ImplicitGrant(GrantTypeBase):
                                              request=request)
 
         for param in ('client_id', 'response_type', 'redirect_uri', 'scope', 'state'):
-            if param in request.duplicate_params:
+            try:
+                duplicate_params = request.duplicate_params
+            except ValueError:
+                raise errors.InvalidRequestError(description='Unable to parse query string', request=request)
+            if param in duplicate_params:
                 raise errors.InvalidRequestError(description='Duplicate %s parameter.' % param, request=request)
 
         # REQUIRED. Value MUST be set to "token".

--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -100,6 +100,17 @@ class ErrorResponseTest(TestCase):
         self.assertRaises(errors.InvalidClientIdError,
                 self.mobile.create_authorization_response, uri, scopes=['foo'])
 
+    def test_empty_parameter(self):
+        uri = 'https://example.com/authorize?client_id=foo&redirect_uri=https%3A%2F%2Fi.b%2Fback&response_type=code&'
+
+        # Authorization code grant
+        self.assertRaises(errors.InvalidRequestError,
+                self.web.validate_authorization_request, uri)
+
+        # Implicit grant
+        self.assertRaises(errors.InvalidRequestError,
+                self.mobile.validate_authorization_request, uri)
+
     def test_invalid_request(self):
         self.validator.get_default_redirect_uri.return_value = 'https://i.b/cb'
         token_uri = 'https://i.b/token'


### PR DESCRIPTION
We've had a issue where a trailing & on the query string 500:s the server. This PR returns a 400 instead on un-parseable query strings.