### PR TITLE
Hide password in logs

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -36,6 +36,7 @@ UNICODE_ASCII_CHARACTER_SET = ('abcdefghijklmnopqrstuvwxyz'
 CLIENT_ID_CHARACTER_SET = (r' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMN'
                            'OPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}')
 
+PASSWORD_PATTERN = re.compile(r'password=[^&]+')
 
 always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                'abcdefghijklmnopqrstuvwxyz'
@@ -408,8 +409,11 @@ class Request(object):
             raise AttributeError(name)
 
     def __repr__(self):
+        body = self.body
+        if 'password=' in body:
+            body = PASSWORD_PATTERN.sub('password=***', body)
         return '<oauthlib.Request url="%s", http_method="%s", headers="%s", body="%s">' % (
-            self.uri, self.http_method, self.headers, self.body)
+            self.uri, self.http_method, self.headers, body)
 
     @property
     def uri_query(self):

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -410,7 +410,7 @@ class Request(object):
 
     def __repr__(self):
         body = self.body
-        if 'password=' in body:
+        if body and 'password=' in body:
             body = PASSWORD_PATTERN.sub('password=***', body)
         return '<oauthlib.Request url="%s", http_method="%s", headers="%s", body="%s">' % (
             self.uri, self.http_method, self.headers, body)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -185,6 +185,15 @@ class RequestTest(TestCase):
         with self.assertRaises(AttributeError):
             getattr(r, 'does_not_exist')
 
+    def test_password_body(self):
+        payload = 'username=foo&password=bar'
+        r = Request(URI, body=payload)
+        self.assertNotIn('bar', repr(r))
+
+        payload = 'password=bar&username=foo'
+        r = Request(URI, body=payload)
+        self.assertNotIn('bar', repr(r))
+
 
 class CaseInsensitiveDictTest(TestCase):
 


### PR DESCRIPTION
Reported by @H0neyBadger https://github.com/idan/oauthlib/issues/345

It is definitely a security bug. We shouldn't track user password in any
situation.