### PR TITLE
Add token_type_hint to the list of default Request params

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -397,6 +397,7 @@ class Request(object):
             "state": None,
             "token": None,
             "user": None,
+            "token_type_hint": None,
         }
         self._params.update(dict(urldecode(self.uri_query)))
         self._params.update(dict(self.decoded_body or []))

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -32,6 +32,14 @@ class RevocationEndpointTest(TestCase):
             self.assertEqual(h, {})
             self.assertEqual(b, '')
             self.assertEqual(s, 200)
+
+        # don't specify token_type_hint
+        body = urlencode([('token', 'foo')])
+        h, b, s = self.endpoint.create_revocation_response(self.uri,
+                headers=self.headers, body=body)
+        self.assertEqual(h, {})
+        self.assertEqual(b, '')
+        self.assertEqual(s, 200)
     
     def test_revoke_token_without_client_authentication(self):
         self.validator.client_authentication_required.return_value = False


### PR DESCRIPTION
From v.1.0, accessing a missing field on request objects raises an AttributeError and this breaks the revocation endpoint, where an access to the `request.token_type_hint` attribute is performed during request validation.
Not sure if other parts of the library are affected, so I preferred to fix `Request`'s constructor instead of catching the error in the `RevocationEndpoint` class.