### PR TITLE
Fix revoke process when working with django-oauth-toolkit

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -71,8 +71,10 @@ class RevocationEndpoint(BaseEndpoint):
                 response_body = '%s(%s);' % (request.callback, response_body)
             return {}, response_body, e.status_code
 
-        self.request_validator.revoke_token(request.token,
-                                            request.token_type_hint, request)
+        self.request_validator.revoke_token(
+                request.token, getattr(request, 'token_type_hint', None),
+                request
+        )
 
         response_body = ''
         if self.enable_jsonp and request.callback:
@@ -124,7 +126,7 @@ class RevocationEndpoint(BaseEndpoint):
             if not self.request_validator.authenticate_client(request):
                 raise InvalidClientError(request=request)
 
-        if (request.token_type_hint and
+        if (hasattr(request, 'token_type_hint') and
                 request.token_type_hint in self.valid_token_types and
                 request.token_type_hint not in self.supported_token_types):
             raise UnsupportedTokenTypeError(request=request)


### PR DESCRIPTION
A fix revocation process when working with django-oauth-toolkit using safer attribute access of request's fields on revocation. There might be an underlying issue (maybe the referenced field was changed?), but this quick fix does the trick.