### PR TITLE
adding validator_log to store what the endpoint computed

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -381,6 +381,7 @@ class Request(object):
         self.body = encode(body)
         self.decoded_body = extract_params(self.body)
         self.oauth_params = []
+        self.validator_log = {}
 
         self._params = {
             "access_token": None,

--- a/oauthlib/oauth1/rfc5849/endpoints/access_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/access_token.py
@@ -192,6 +192,13 @@ class AccessTokenEndpoint(BaseEndpoint):
 
         valid_signature = self._check_signature(request, is_token_request=True)
 
+        # log the results to the validator_log
+        # this lets us handle internal reporting and analysis
+        request.validator_log['client'] = valid_client
+        request.validator_log['resource_owner'] = valid_resource_owner
+        request.validator_log['verifier'] = valid_verifier
+        request.validator_log['signature'] = valid_signature
+
         # We delay checking validity until the very end, using dummy values for
         # calculations and fetching secrets/keys to ensure the flow of every
         # request remains almost identical regardless of whether valid values

--- a/oauthlib/oauth1/rfc5849/endpoints/request_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/request_token.py
@@ -187,6 +187,13 @@ class RequestTokenEndpoint(BaseEndpoint):
 
         valid_signature = self._check_signature(request)
 
+        # log the results to the validator_log
+        # this lets us handle internal reporting and analysis
+        request.validator_log['client'] = valid_client
+        request.validator_log['realm'] = valid_realm
+        request.validator_log['callback'] = valid_redirect
+        request.validator_log['signature'] = valid_signature
+
         # We delay checking validity until the very end, using dummy values for
         # calculations and fetching secrets/keys to ensure the flow of every
         # request remains almost identical regardless of whether valid values

--- a/oauthlib/oauth1/rfc5849/endpoints/resource.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/resource.py
@@ -142,6 +142,13 @@ class ResourceEndpoint(BaseEndpoint):
 
         valid_signature = self._check_signature(request)
 
+        # log the results to the validator_log
+        # this lets us handle internal reporting and analysis
+        request.validator_log['client'] = valid_client
+        request.validator_log['resource_owner'] = valid_resource_owner
+        request.validator_log['realm'] = valid_realm
+        request.validator_log['signature'] = valid_signature
+
         # We delay checking validity until the very end, using dummy values for
         # calculations and fetching secrets/keys to ensure the flow of every
         # request remains almost identical regardless of whether valid values

--- a/oauthlib/oauth1/rfc5849/endpoints/signature_only.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/signature_only.py
@@ -61,6 +61,11 @@ class SignatureOnlyEndpoint(BaseEndpoint):
 
         valid_signature = self._check_signature(request)
 
+        # log the results to the validator_log
+        # this lets us handle internal reporting and analysis
+        request.validator_log['client'] = valid_client
+        request.validator_log['signature'] = valid_signature
+
         # We delay checking validity until the very end, using dummy values for
         # calculations and fetching secrets/keys to ensure the flow of every
         # request remains almost identical regardless of whether valid values

--- a/tests/oauth1/rfc5849/endpoints/test_resource.py
+++ b/tests/oauth1/rfc5849/endpoints/test_resource.py
@@ -50,18 +50,33 @@ class ResourceEndpointTest(TestCase):
         v, r = self.endpoint.validate_protected_resource_request(
                 self.uri, headers=self.headers)
         self.assertFalse(v)
+        # the validator log should have `False` values
+        self.assertFalse(r.validator_log['client'])
+        self.assertTrue(r.validator_log['realm'])
+        self.assertTrue(r.validator_log['resource_owner'])
+        self.assertTrue(r.validator_log['signature'])
 
     def test_validate_access_token(self):
         self.validator.validate_access_token.return_value = False
         v, r = self.endpoint.validate_protected_resource_request(
                 self.uri, headers=self.headers)
         self.assertFalse(v)
+        # the validator log should have `False` values
+        self.assertTrue(r.validator_log['client'])
+        self.assertTrue(r.validator_log['realm'])
+        self.assertFalse(r.validator_log['resource_owner'])
+        self.assertTrue(r.validator_log['signature'])
 
     def test_validate_realms(self):
         self.validator.validate_realms.return_value = False
         v, r = self.endpoint.validate_protected_resource_request(
                 self.uri, headers=self.headers)
         self.assertFalse(v)
+        # the validator log should have `False` values
+        self.assertTrue(r.validator_log['client'])
+        self.assertFalse(r.validator_log['realm'])
+        self.assertTrue(r.validator_log['resource_owner'])
+        self.assertTrue(r.validator_log['signature'])
 
     def test_validate_signature(self):
         client = Client('foo',
@@ -71,6 +86,11 @@ class ResourceEndpointTest(TestCase):
         v, r = self.endpoint.validate_protected_resource_request(
                 self.uri, headers=headers)
         self.assertFalse(v)
+        # the validator log should have `False` values
+        self.assertTrue(r.validator_log['client'])
+        self.assertTrue(r.validator_log['realm'])
+        self.assertTrue(r.validator_log['resource_owner'])
+        self.assertFalse(r.validator_log['signature'])
 
     def test_valid_request(self):
         v, r = self.endpoint.validate_protected_resource_request(
@@ -79,3 +99,5 @@ class ResourceEndpointTest(TestCase):
         self.validator.validate_timestamp_and_nonce.assert_called_once_with(
              self.client.client_key, ANY, ANY, ANY,
              access_token=self.client.resource_owner_key)
+        # everything in the validator_log should be `True`
+        self.assertTrue(all(r.validator_log.items()))


### PR DESCRIPTION
This adds logging of what the endpoint computed to the request as a dict on the  `validator_log` attribute.  

see https://github.com/idan/oauthlib/issues/378

This is most useful on protected resources, where it lets you know why the overall validation failed.