### PR TITLE
Fix for null scope

### DIFF
--- a/oauthlib/oauth2/rfc6749/utils.py
+++ b/oauthlib/oauth2/rfc6749/utils.py
@@ -35,7 +35,7 @@ def scope_to_list(scope):
     if isinstance(scope, (tuple, list, set)):
         return [unicode_type(s) for s in scope]
     elif scope is None:
-        return None
+        return []
     else:
         return scope.strip().split(" ")
 


### PR DESCRIPTION
Our PHP OAuth2 server responds to token request with
{"access_token":"20fdab98f6518335db837c2039125ae16b523eb86","expires_in":"7200","token_type":"Bearer","scope":null}

Without this fix, parse_token_response fails with:
  File "/usr/local/lib/python2.7/dist-packages/oauthlib/oauth2/rfc6749/tokens.py", line 32, in **init**
    self._new_scope = set(utils.scope_to_list(params['scope']))
TypeError: 'NoneType' object is not iterable

The reason is that scope_to_list returns None for this case and set(None) results in TypeError. It feels logical to me that scope_to_list should always return a list.
