### PR TITLE
Add 'python' info to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ OAuthLib
 ========
 
 *A generic, spec-compliant, thorough implementation of the OAuth request-signing
-logic.*
+logic for python*
 
 .. image:: https://travis-ci.org/idan/oauthlib.png?branch=master
   :target: https://travis-ci.org/idan/oauthlib


### PR DESCRIPTION
Updated readme to say that the library is for *Python*.

I landed here just searching for generic **oauth** docs, and it took me like 30 seconds to realize that this library is a Python-specific implementation.