### PR TITLE
Make refresh token as optional on Authentication code grant.

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -95,8 +95,9 @@ class AuthorizationCodeGrant(GrantTypeBase):
     .. _`Authorization Code Grant`: http://tools.ietf.org/html/rfc6749#section-4.1
     """
 
-    def __init__(self, request_validator=None):
+    def __init__(self, request_validator=None, refresh_token=True):
         self.request_validator = request_validator or RequestValidator()
+        self.refresh_token = refresh_token
 
     def create_authorization_code(self, request):
         """Generates an authorization grant represented as a dictionary."""
@@ -237,7 +238,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
             log.debug('Client error during validation of %r. %r.', request, e)
             return headers, e.json, e.status_code
 
-        token = token_handler.create_token(request, refresh_token=True)
+        token = token_handler.create_token(request, refresh_token=self.refresh_token)
         self.request_validator.invalidate_authorization_code(
             request.client_id, request.code, request)
         return headers, json.dumps(token), 200

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -70,6 +70,23 @@ class AuthorizationCodeGrantTest(TestCase):
         self.assertTrue(self.mock_validator.validate_grant_type.called)
         self.assertTrue(self.mock_validator.invalidate_authorization_code.called)
 
+    def test_create_token_response_without_refresh_token(self):
+        self.auth.refresh_token = False  # Not to issue refresh token.
+
+        bearer = BearerToken(self.mock_validator)
+        h, token, s = self.auth.create_token_response(self.request, bearer)
+        token = json.loads(token)
+        self.assertIn('access_token', token)
+        self.assertNotIn('refresh_token', token)
+        self.assertIn('expires_in', token)
+        self.assertIn('scope', token)
+        self.assertTrue(self.mock_validator.client_authentication_required.called)
+        self.assertTrue(self.mock_validator.authenticate_client.called)
+        self.assertTrue(self.mock_validator.validate_code.called)
+        self.assertTrue(self.mock_validator.confirm_redirect_uri.called)
+        self.assertTrue(self.mock_validator.validate_grant_type.called)
+        self.assertTrue(self.mock_validator.invalidate_authorization_code.called)
+
     def test_invalid_request(self):
         del self.request.code
         self.assertRaises(errors.InvalidRequestError, self.auth.validate_token_request,


### PR DESCRIPTION
As same as https://github.com/idan/oauthlib/pull/275 Pull Request, authentication code grant won't  require refresh token. 

I added new kwarg `refresh_token=True` for the constructor of AuthenticationCodeGrant.
It allows users to disable refresh token.
Of cause it's True by default, so this change won't break backward compatibility.
