### PR TITLE
Fix for oauth2 token processing

### DIFF
--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -28,7 +28,7 @@ class OAuth2Token(dict):
     def __init__(self, params, old_scope=None):
         super(OAuth2Token, self).__init__(params)
         self._new_scope = None
-        if 'scope' in params:
+        if 'scope' in params and params['scope']:
             self._new_scope = set(utils.scope_to_list(params['scope']))
         if old_scope is not None:
             self._old_scope = set(utils.scope_to_list(old_scope))


### PR DESCRIPTION
When 'scope' is passed to ```OAuth2Token.__init__()``` but it is None, a NoneType exception will be raised, so I updated the check to make sure scope is not None.