### PR TITLE
Add request token for OAuth 1

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -393,6 +393,7 @@ class Request(object):
             "grant_type": None,
             "redirect_uri": None,
             "refresh_token": None,
+            "request_token": None,
             "response_type": None,
             "scope": None,
             "scopes": None,


### PR DESCRIPTION
request_token is widely used in OAuth 1.

https://github.com/lepture/flask-oauthlib/issues/238