### PR TITLE
Set issue_new_refresh_tokens in RefreshTokenGrant.__init__

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -22,12 +22,9 @@ class RefreshTokenGrant(GrantTypeBase):
     .. _`Refresh token grant`: http://tools.ietf.org/html/rfc6749#section-6
     """
 
-    @property
-    def issue_new_refresh_tokens(self):
-        return True
-
     def __init__(self, request_validator=None, issue_new_refresh_tokens=True):
         self.request_validator = request_validator or RequestValidator()
+        self.issue_new_refresh_tokens = issue_new_refresh_tokens
 
     def create_token_response(self, request, token_handler):
         """Create a new access token from a refresh_token.


### PR DESCRIPTION
Now `issue_new_refresh_tokens` parameter in `__init__` method is not used and property with the same name is introduced. Probably would be better to remove this property and parametrize it in constructor.