### PR TITLE
Cast body to a string for regex - fixes #424

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -416,7 +416,7 @@ class Request(object):
         body = self.body
         headers = self.headers.copy()
         if body:
-            body = SANITIZE_PATTERN.sub('\1<SANITIZED>', body)
+            body = SANITIZE_PATTERN.sub('\1<SANITIZED>', str(body))
         if 'Authorization' in headers:
             headers['Authorization'] = '<SANITIZED>'
         return '<oauthlib.Request url="%s", http_method="%s", headers="%s", body="%s">' % (


### PR DESCRIPTION
This just ensures that when we go to sanitize the body for logging, it is actually a string