### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ you'd like to know, or discuss it in our `G+ community`_, or even better, send a
 pull request!
 
 .. _`G+ community`: https://plus.google.com/communities/101889017375384052571
-.. _`Read the Docs`: https://oauthlib.readthedocs.org/en/latest/index.html
+.. _`Read the Docs`: https://oauthlib.readthedocs.io/en/latest/index.html
 
 Interested in making OAuth requests?
 ------------------------------------
@@ -96,6 +96,6 @@ Changelog
 completed, for providers as well as clients.* See `supported features`_ for
 details.
 
-.. _`supported features`: http://oauthlib.readthedocs.org/en/latest/feature_matrix.html
+.. _`supported features`: https://oauthlib.readthedocs.io/en/latest/feature_matrix.html
 
 For a full changelog see ``CHANGELOG.rst``.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -147,7 +147,7 @@ version. For Ubuntu you can easily install all after adding one ppa.
    $ sudo apt-get install python3.3 python3.3-dev
    $ sudo apt-get install pypy pypy-dev
 
-.. _`Tox`: http://tox.readthedocs.org/en/latest/install.html
+.. _`Tox`: https://tox.readthedocs.io/en/latest/install.html
 .. _`virtualenv`: http://www.virtualenv.org/en/latest/#installation
 
 If you add code you need to add tests!

--- a/examples/skeleton_oauth2_web_application_server.py
+++ b/examples/skeleton_oauth2_web_application_server.py
@@ -3,7 +3,7 @@
 # for dispensing Bearer Tokens.
 
 # This example is meant to act as a supplement to the documentation,
-# see http://oauthlib.readthedocs.org/en/latest/.
+# see https://oauthlib.readthedocs.io/en/latest/.
 
 from oauthlib.oauth2 import RequestValidator, WebApplicationServer
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.