### PR TITLE
Fix TypeError in openid_connect

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -64,7 +64,7 @@ class AuthCodeGrantDispatcher(object):
     def _handler_for_request(self, request):
         handler = self.default_auth_grant
 
-        if "openid" in request.scopes:
+        if request.scopes and "openid" in request.scopes:
             handler = self.oidc_auth_grant
 
         log.debug('Selecting handler for request %r.', handler)


### PR DESCRIPTION
This pull request fixes the "TypeError: argument of type 'NoneType' is not iterable" that was caused by calling the openid_connect validate_authorization method with a request where request.scopes was
set to None (fixes #436).
