### PR TITLE
Ensure request.client_id in grant authorization_code

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -439,6 +439,8 @@ class AuthorizationCodeGrant(GrantTypeBase):
                       request.redirect_uri, request.client_id, request.client)
             raise errors.AccessDeniedError(request=request)
 
+        request.client_id = request.client_id or request.client.client_id
+
         for validator in self._token_validators:
             validator(request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -415,6 +415,8 @@ class AuthorizationCodeGrant(GrantTypeBase):
                                       'request.client.client_id attribute '
                                       'in authenticate_client.')
 
+        request.client_id = request.client_id or request.client.client_id
+
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
@@ -438,8 +440,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
             log.debug('Redirect_uri (%r) invalid for client %r (%r).',
                       request.redirect_uri, request.client_id, request.client)
             raise errors.AccessDeniedError(request=request)
-
-        request.client_id = request.client_id or request.client.client_id
 
         for validator in self._token_validators:
             validator(request)


### PR DESCRIPTION
In grant type authorization_code, `create_token_response()` and `validate_token_request()` are using `request.client_id`:
https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py#L275

But `validate_token_request()` is only checking, if `request.client.client_id` is set:
https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py#L413-L416

When e.g. using Flask-Oauthlib, the `request.client_id` is not set in token requests. The client id is only available in `request.client.client_id`.

**That leads to a critical bug, that authorization codes are never invalidated/deleted**, because the passed client_id is always `None` and the query to find the code fails and the invalidation is silently ignored (that's out of scope here, I'll create an issue in its project as well).

This can be fixed by ensuring `request.client_id` like it's already done in e.g. the client_credentials grant:
https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py#L120

Best
Fabian
