### PR TITLE
Updating request.scopes to a list to fix the NoneType is not iterable error.

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/authorization.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/authorization.py
@@ -107,7 +107,7 @@ class AuthorizationEndpoint(BaseEndpoint):
         """Extract response_type and route to the designated handler."""
         request = Request(
             uri, http_method=http_method, body=body, headers=headers)
-        request.scopes = None
+        request.scopes = []
         response_type_handler = self.response_types.get(
             request.response_type, self.default_response_type_handler)
         return response_type_handler.validate_authorization_request(request)


### PR DESCRIPTION
Scopes are initialised as request.scopes = None in validate_authorization_request() method and response_type_handler.validate_authorization_request(request) is called immediately afterwards.
Now, in method _handler_for_request() called by validate_authorization_request() there's a call to if "openid" in request.scopes, which expects of course request.scopes to be an Iterable.

Since I couldn't find any other way this library to work, please merge it so that it's available to be installed via pip.
Thanks!
