### PR TITLE
Improve validator registration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ David Baumgold
 Juan Fabio García Solero
 Omer Katz
 Joel Stevenson
+Brendan McCollam

--- a/docs/oauth2/grants/authcode.rst
+++ b/docs/oauth2/grants/authcode.rst
@@ -3,3 +3,4 @@ Authorization Code Grant
 
 .. autoclass:: oauthlib.oauth2.AuthorizationCodeGrant
     :members:
+    :inherited-members:

--- a/docs/oauth2/grants/credentials.rst
+++ b/docs/oauth2/grants/credentials.rst
@@ -3,3 +3,4 @@ Client Credentials Grant
 
 .. autoclass:: oauthlib.oauth2.ClientCredentialsGrant
     :members:
+    :inherited-members:

--- a/docs/oauth2/grants/custom_validators.rst
+++ b/docs/oauth2/grants/custom_validators.rst
@@ -1,0 +1,5 @@
+Custom Validators
+-----------------
+
+.. autoclass:: oauthlib.oauth2.rfc6749.grant_types.base.ValidatorsContainer
+    :members:

--- a/docs/oauth2/grants/grants.rst
+++ b/docs/oauth2/grants/grants.rst
@@ -9,6 +9,7 @@ Grant types
     implicit
     password
     credentials
+    custom_validators
     jwt
 
 Grant types are what make OAuth 2 so flexible. The Authorization Code grant is
@@ -26,7 +27,7 @@ attempts to cater for easy inclusion of this as much as possible.
 
 OAuthlib also offers hooks for registering your own custom validations for use
 with the existing grant type handlers
-(:py:meth:`oauthlib.oauth2.AuthorizationCodeGrant.register_authorization_validator`).
+(:py:class:`oauthlib.oauth2.rfc6749.grant_types.base.ValidatorsContainer`).
 In some situations, this may be more convenient than subclassing or writing
 your own extension grant type.
 

--- a/docs/oauth2/grants/grants.rst
+++ b/docs/oauth2/grants/grants.rst
@@ -24,6 +24,12 @@ resources in various ways with different security credentials.
 Naturally, OAuth 2 allows for extension grant types to be defined and OAuthLib
 attempts to cater for easy inclusion of this as much as possible.
 
+OAuthlib also offers hooks for registering your own custom validations for use
+with the existing grant type handlers
+(:py:meth:`oauthlib.oauth2.AuthorizationCodeGrant.register_authorization_validator`).
+In some situations, this may be more convenient than subclassing or writing
+your own extension grant type.
+
 Certain grant types allow the issuing of refresh tokens which will allow a
 client to request new tokens for as long as you as provider allow them too. In
 general, OAuth 2 tokens should expire quickly and rather than annoying the user

--- a/docs/oauth2/grants/implicit.rst
+++ b/docs/oauth2/grants/implicit.rst
@@ -3,3 +3,4 @@ Implicit Grant
 
 .. autoclass:: oauthlib.oauth2.ImplicitGrant
     :members:
+    :inherited-members:

--- a/docs/oauth2/grants/password.rst
+++ b/docs/oauth2/grants/password.rst
@@ -3,3 +3,4 @@ Resource Owner Password Credentials Grant
 
 .. autoclass:: oauthlib.oauth2.ResourceOwnerPasswordCredentialsGrant
     :members:
+    :inherited-members:

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -323,7 +323,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # populated through the use of specific exceptions.
 
         request_info = {}
-        for validator in self._auth_validators_run_before_standard_ones:
+        for validator in self.custom_validators.pre_auth:
             request_info.update(validator(request))
 
         # REQUIRED.
@@ -354,7 +354,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
             'request': request
         })
 
-        for validator in self._auth_validators_run_after_standard_ones:
+        for validator in self.custom_validators.post_auth:
             request_info.update(validator(request))
 
         return request.scopes, request_info
@@ -364,7 +364,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
         if request.grant_type not in ('authorization_code', 'openid'):
             raise errors.UnsupportedGrantTypeError(request=request)
 
-        for validator in self._token_validators_run_before_standard_ones:
+        for validator in self.custom_validators.pre_token:
             validator(request)
 
         if request.code is None:
@@ -423,5 +423,5 @@ class AuthorizationCodeGrant(GrantTypeBase):
                       request.redirect_uri, request.client_id, request.client)
             raise errors.AccessDeniedError(request=request)
 
-        for validator in self._token_validators_run_after_standard_ones:
+        for validator in self.custom_validators.post_token:
             validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -13,7 +13,6 @@ from oauthlib.uri_validate import is_absolute_uri
 
 from .base import GrantTypeBase
 from .. import errors
-from ..request_validator import RequestValidator
 
 log = logging.getLogger(__name__)
 
@@ -96,31 +95,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
     """
 
     default_response_mode = 'query'
-
-    def __init__(self, request_validator=None, refresh_token=True):
-        self.request_validator = request_validator or RequestValidator()
-        self.refresh_token = refresh_token
-
-        self._authorization_validators = []
-        self._token_validators = []
-        self._code_modifiers = []
-        self._token_modifiers = []
-        self.response_types = ['code']
-
-    def register_response_type(self, response_type):
-        self.response_types.append(response_type)
-
-    def register_authorization_validator(self, validator):
-        self._authorization_validators.append(validator)
-
-    def register_token_validator(self, validator):
-        self._token_validators.append(validator)
-
-    def register_code_modifier(self, modifier):
-        self._code_modifiers.append(modifier)
-
-    def register_token_modifier(self, modifier):
-        self._token_modifiers.append(modifier)
+    response_types = ['code']
 
     def create_authorization_code(self, request):
         """Generates an authorization grant represented as a dictionary."""
@@ -347,6 +322,10 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # Note that the correct parameters to be added are automatically
         # populated through the use of specific exceptions.
 
+        request_info = {}
+        for validator in self._auth_validators_run_before_standard_ones:
+            request_info.update(validator(request))
+
         # REQUIRED.
         if request.response_type is None:
             raise errors.MissingResponseTypeError(request=request)
@@ -367,15 +346,15 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # http://tools.ietf.org/html/rfc6749#section-3.3
         self.validate_scopes(request)
 
-        request_info = {
+        request_info.update({
             'client_id': request.client_id,
             'redirect_uri': request.redirect_uri,
             'response_type': request.response_type,
             'state': request.state,
             'request': request
-        }
+        })
 
-        for validator in self._authorization_validators:
+        for validator in self._auth_validators_run_after_standard_ones:
             request_info.update(validator(request))
 
         return request.scopes, request_info
@@ -384,6 +363,9 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # REQUIRED. Value MUST be set to "authorization_code".
         if request.grant_type not in ('authorization_code', 'openid'):
             raise errors.UnsupportedGrantTypeError(request=request)
+
+        for validator in self._token_validators_run_before_standard_ones:
+            validator(request)
 
         if request.code is None:
             raise errors.InvalidRequestError(
@@ -441,6 +423,5 @@ class AuthorizationCodeGrant(GrantTypeBase):
                       request.redirect_uri, request.client_id, request.client)
             raise errors.AccessDeniedError(request=request)
 
-        for validator in self._token_validators:
+        for validator in self._token_validators_run_after_standard_ones:
             validator(request)
-

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -44,12 +44,38 @@ class GrantTypeBase(object):
         self.response_types.append(response_type)
 
     def register_authorization_validator(self, validator, after_standard=True):
+        """
+        Register a validator callable to be invoked during calls to the
+        authorization endpoint.
+
+        :param callable validator: callable that takes a request object and returns a
+                          mapping of items to be included with the authorization validation
+                          response.
+        :param bool after_standard: default: True, If True, the custom
+                                    validator is called after the standard authorization
+                                    validations. If False, the custom valdator is called before
+                                    the standard validations.
+        :returns: None
+        """
         if after_standard:
             self._auth_validators_run_after_standard_ones.append(validator)
         else:
             self._auth_validators_run_before_standard_ones.append(validator)
 
     def register_token_validator(self, validator, after_standard=True):
+        """
+        Register a validator callable to be invoked during calls to the
+        token endpoint (or the authorization endpoint during the implicit grant,
+        flow which returns tokens directly from the authorization endpoint).
+
+
+        :param callable validator: callable that takes a request object and returns None or
+                          raises an exception if appropriate.
+        :param bool after_standard: default: True, If True, the custom
+                               validator is called after the standard token validations. If False,
+                               the custom valdator is called before the standard validations.
+        :returns: None
+        """
         if after_standard:
             self._token_validators_run_after_standard_ones.append(validator)
         else:

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -15,14 +15,48 @@ from ..request_validator import RequestValidator
 log = logging.getLogger(__name__)
 
 class ValidatorsContainer(object):
-
     """
-        Container object for holding validator callables to be invoked.
+        Container object for holding custom validator callables to be invoked
+        as part of the grant type `validate_authorization_request()` or
+        `validate_authorization_request()` methods on the various grant types.
+
+        Authorization validators must be callables that take a request object and
+        return a dict, which may contain items to be added to the `request_info`
+        returned from the grant_type after validation.
+
+        Token validators must be callables that take a request object and
+        return None.
+
+        Both authorization validators and token validators may raise OAuth2
+        exceptions if validation conditions fail.
+
+        Authorization validators added to `pre_auth` will be run BEFORE
+        the standard validations (but after the critical ones that raise
+        fatal errors) as part of `validate_authorization_request()`
+
+        Authorization validators added to `post_auth` will be run AFTER
+        the standard validations as part of `validate_authorization_request()`
+
+        Token validators added to `pre_token` will be run BEFORE
+        the standard validations as part of `validate_token_request()`
+
+        Token validators added to `post_token` will be run AFTER
+        the standard validations as part of `validate_token_request()`
+
+        For example:
+
+        >>> def my_auth_validator(request):
+        ...    return {'myval': True}
+        >>> auth_code_grant = AuthorizationCodeGrant(request_validator)
+        >>> auth_code_grant.custom_validators.pre_auth.append(my_auth_validator)
+        >>> def my_token_validator(request):
+        ...     if not request.everything_okay:
+        ...         raise errors.OAuth2Error("uh-oh")
+        >>> auth_code_grant.custom_validators.post_token.append(my_token_validator)
     """
 
-    def __init__(self,
-                 post_auth=None, post_token=None,
-                 pre_auth=None, pre_token=None):
+    def __init__(self, post_auth, post_token,
+                 pre_auth, pre_token):
         self.pre_auth = pre_auth
         self.post_auth = post_auth
         self.pre_token = pre_token
@@ -67,6 +101,7 @@ class GrantTypeBase(object):
                 msg = ("{} does not support authorization validators. Use "
                        "token validators instead.").format(self.__class__.__name__)
                 raise ValueError(msg)
+            # Using tuples here because they can't be appended to:
             post_auth, pre_auth = (), ()
         self.custom_validators = ValidatorsContainer(post_auth, post_token,
                                                      pre_auth, pre_token)

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -85,7 +85,7 @@ class ClientCredentialsGrant(GrantTypeBase):
         return headers, json.dumps(token), 200
 
     def validate_token_request(self, request):
-        for validator in self._token_validators_run_before_standard_ones:
+        for validator in self.custom_validators.pre_token:
             validator(request)
 
         if not getattr(request, 'grant_type', None):
@@ -116,5 +116,5 @@ class ClientCredentialsGrant(GrantTypeBase):
         request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
 
-        for validator in self._token_validators_run_after_standard_ones:
+        for validator in self.custom_validators.post_token:
             validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -50,13 +50,6 @@ class ClientCredentialsGrant(GrantTypeBase):
     .. _`Client Credentials Grant`: http://tools.ietf.org/html/rfc6749#section-4.4
     """
 
-    def __init__(self, request_validator=None):
-        self.request_validator = request_validator or RequestValidator()
-        self._token_modifiers = []
-
-    def register_token_modifier(self, modifier):
-        self._token_modifiers.append(modifier)
-
     def create_token_response(self, request, token_handler):
         """Return token or error in JSON format.
 
@@ -92,6 +85,9 @@ class ClientCredentialsGrant(GrantTypeBase):
         return headers, json.dumps(token), 200
 
     def validate_token_request(self, request):
+        for validator in self._token_validators_run_before_standard_ones:
+            validator(request)
+
         if not getattr(request, 'grant_type', None):
             raise errors.InvalidRequestError('Request is missing grant type.',
                                              request=request)
@@ -119,3 +115,6 @@ class ClientCredentialsGrant(GrantTypeBase):
         log.debug('Authorizing access to user %r.', request.user)
         request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
+
+        for validator in self._token_validators_run_after_standard_ones:
+            validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -317,9 +317,7 @@ class ImplicitGrant(GrantTypeBase):
 
         # Then check for normal errors.
 
-        request_info = {}
-
-        self._run_custom_validators(request, request_info,
+        request_info = self._run_custom_validators(request,
                             self._auth_validators_run_before_standard_ones,
                             self._token_validators_run_before_standard_ones)
 
@@ -363,18 +361,21 @@ class ImplicitGrant(GrantTypeBase):
                 'request': request,
         })
 
-        self._run_custom_validators(request, request_info,
+        request_info = self._run_custom_validators(request,
                             self._auth_validators_run_after_standard_ones,
-                            self._token_validators_run_after_standard_ones)
+                            self._token_validators_run_after_standard_ones,
+                            request_info)
 
         return request.scopes, request_info
 
 
     def _run_custom_validators(self,
                                request,
-                               request_info,
                                auth_validators,
-                               token_validators):
+                               token_validators,
+                               request_info=None):
+        # Make a copy so we don't modify the existing request_info dict
+        request_info = {} if request_info is None else request_info.copy()
         # For implicit grant, auth_validators and token_validators are
         # basically equivalent since the token is returned from the
         # authorization endpoint.

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -5,7 +5,6 @@ oauthlib.oauth2.rfc6749.grant_types
 """
 from __future__ import unicode_literals, absolute_import
 
-from itertools import chain
 import logging
 
 from oauthlib import common
@@ -318,8 +317,7 @@ class ImplicitGrant(GrantTypeBase):
         # Then check for normal errors.
 
         request_info = self._run_custom_validators(request,
-                            self._auth_validators_run_before_standard_ones,
-                            self._token_validators_run_before_standard_ones)
+                                self.custom_validators.all_pre)
 
 
         # If the resource owner denies the access request or if the request
@@ -362,8 +360,7 @@ class ImplicitGrant(GrantTypeBase):
         })
 
         request_info = self._run_custom_validators(request,
-                            self._auth_validators_run_after_standard_ones,
-                            self._token_validators_run_after_standard_ones,
+                            self.custom_validators.all_post,
                             request_info)
 
         return request.scopes, request_info
@@ -371,15 +368,14 @@ class ImplicitGrant(GrantTypeBase):
 
     def _run_custom_validators(self,
                                request,
-                               auth_validators,
-                               token_validators,
+                               validations,
                                request_info=None):
         # Make a copy so we don't modify the existing request_info dict
         request_info = {} if request_info is None else request_info.copy()
         # For implicit grant, auth_validators and token_validators are
         # basically equivalent since the token is returned from the
         # authorization endpoint.
-        for validator in chain(auth_validators, token_validators):
+        for validator in validations:
             result = validator(request)
             if result is not None:
                 request_info.update(result)

--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -77,10 +77,33 @@ class AuthCodeGrantDispatcher(object):
         return self._handler_for_request(request).validate_authorization_request(request)
 
 
-class OpenIDConnectBase(GrantTypeBase):
+class OpenIDConnectBase(object):
 
-    def __init__(self, request_validator=None):
-        self.request_validator = request_validator or RequestValidator()
+    # Just proxy the majority of method calls through to the
+    # proxy_target grant type handler, which will usually be either
+    # the standard OAuth2 AuthCode or Implicit grant types.
+    def __getattr__(self, attr):
+        return getattr(self.proxy_target, attr)
+
+    def __setattr__(self, attr, value):
+        proxied_attrs = set(('refresh_token', 'response_types'))
+        if attr in proxied_attrs:
+            setattr(self.proxy_target, attr, value)
+        else:
+            super(OpenIDConnectBase, self).__setattr__(attr, value)
+
+    def validate_authorization_request(self, request):
+        """Validates the OpenID Connect authorization request parameters.
+
+        :returns: (list of scopes, dict of request info)
+        """
+        # If request.prompt is 'none' then no login/authorization form should
+        # be presented to the user. Instead, a silent login/authorization
+        # should be performed.
+        if request.prompt == 'none':
+            raise OIDCNoPrompt()
+        else:
+            return self.proxy_target.validate_authorization_request(request)
 
     def _inflate_claims(self, request):
         # this may be called multiple times in a single request so make sure we only de-serialize the claims once
@@ -309,135 +332,40 @@ class OpenIDConnectBase(GrantTypeBase):
 
 class OpenIDConnectAuthCode(OpenIDConnectBase):
 
-    def __init__(self, request_validator=None):
-        self.request_validator = request_validator or RequestValidator()
-        super(OpenIDConnectAuthCode, self).__init__(
-            request_validator=self.request_validator)
-        self.auth_code = AuthorizationCodeGrant(
-            request_validator=self.request_validator)
-        self.auth_code.register_authorization_validator(
+    def __init__(self, request_validator=None, **kwargs):
+        self.proxy_target = AuthorizationCodeGrant(
+            request_validator=request_validator, **kwargs)
+        self.register_authorization_validator(
             self.openid_authorization_validator)
-        self.auth_code.register_token_modifier(self.add_id_token)
-
-    @property
-    def refresh_token(self):
-        return self.auth_code.refresh_token
-
-    @refresh_token.setter
-    def refresh_token(self, value):
-        self.auth_code.refresh_token = value
-
-    def create_authorization_code(self, request):
-        return self.auth_code.create_authorization_code(request)
-
-    def create_authorization_response(self, request, token_handler):
-        return self.auth_code.create_authorization_response(
-            request, token_handler)
-
-    def create_token_response(self, request, token_handler):
-        return self.auth_code.create_token_response(request, token_handler)
-
-    def validate_authorization_request(self, request):
-        """Validates the OpenID Connect authorization request parameters.
-
-        :returns: (list of scopes, dict of request info)
-        """
-        # If request.prompt is 'none' then no login/authorization form should
-        # be presented to the user. Instead, a silent login/authorization
-        # should be performed.
-        if request.prompt == 'none':
-            raise OIDCNoPrompt()
-        else:
-            return self.auth_code.validate_authorization_request(request)
-
-    def validate_token_request(self, request):
-        return self.auth_code.validate_token_request(request)
-
+        self.register_token_modifier(self.add_id_token)
 
 class OpenIDConnectImplicit(OpenIDConnectBase):
 
-    def __init__(self, request_validator=None):
-        self.request_validator = request_validator or RequestValidator()
-        super(OpenIDConnectImplicit, self).__init__(
-            request_validator=self.request_validator)
-        self.implicit = ImplicitGrant(
-            request_validator=request_validator)
-        self.implicit.register_response_type('id_token')
-        self.implicit.register_response_type('id_token token')
-        self.implicit.register_authorization_validator(
+    def __init__(self, request_validator=None, **kwargs):
+        self.proxy_target = ImplicitGrant(
+            request_validator=request_validator, **kwargs)
+        self.register_response_type('id_token')
+        self.register_response_type('id_token token')
+        self.register_authorization_validator(
             self.openid_authorization_validator)
-        self.implicit.register_authorization_validator(
+        self.register_authorization_validator(
             self.openid_implicit_authorization_validator)
-        self.implicit.register_token_modifier(self.add_id_token)
-
-    def create_authorization_response(self, request, token_handler):
-        return self.create_token_response(request, token_handler)
-
-    def create_token_response(self, request, token_handler):
-        return self.implicit.create_authorization_response(
-            request, token_handler)
-
-    def validate_authorization_request(self, request):
-        """Validates the OpenID Connect authorization request parameters.
-
-        :returns: (list of scopes, dict of request info)
-        """
-        # If request.prompt is 'none' then no login/authorization form should
-        # be presented to the user. Instead, a silent login/authorization
-        # should be performed.
-        if request.prompt == 'none':
-            raise OIDCNoPrompt()
-        else:
-            return self.implicit.validate_authorization_request(request)
-
+        self.register_token_modifier(self.add_id_token)
 
 class OpenIDConnectHybrid(OpenIDConnectBase):
 
-    def __init__(self, request_validator=None):
+    def __init__(self, request_validator=None, **kwargs):
         self.request_validator = request_validator or RequestValidator()
 
-        self.auth_code = AuthorizationCodeGrant(
-            request_validator=request_validator)
-        self.auth_code.register_response_type('code id_token')
-        self.auth_code.register_response_type('code token')
-        self.auth_code.register_response_type('code id_token token')
-        self.auth_code.register_authorization_validator(
+        self.proxy_target = AuthorizationCodeGrant(
+            request_validator=request_validator, **kwargs)
+        self.register_response_type('code id_token')
+        self.register_response_type('code token')
+        self.register_response_type('code id_token token')
+        self.register_authorization_validator(
             self.openid_authorization_validator)
-        self.auth_code.register_code_modifier(self.add_token)
-        self.auth_code.register_code_modifier(self.add_id_token)
-        self.auth_code.register_token_modifier(self.add_id_token)
-
-    @property
-    def refresh_token(self):
-        return self.auth_code.refresh_token
-
-    @refresh_token.setter
-    def refresh_token(self, value):
-        self.auth_code.refresh_token = value
-
-    def create_authorization_code(self, request):
-        return self.auth_code.create_authorization_code(request)
-
-    def create_authorization_response(self, request, token_handler):
-        return self.auth_code.create_authorization_response(
-            request, token_handler)
-
-    def create_token_response(self, request, token_handler):
-        return self.auth_code.create_token_response(request, token_handler)
-
-    def validate_authorization_request(self, request):
-        """Validates the OpenID Connect authorization request parameters.
-
-        :returns: (list of scopes, dict of request info)
-        """
-        # If request.prompt is 'none' then no login/authorization form should
-        # be presented to the user. Instead, a silent login/authorization
-        # should be performed.
-        if request.prompt == 'none':
-            raise OIDCNoPrompt()
-        else:
-            return self.auth_code.validate_authorization_request(request)
-
-    def validate_token_request(self, request):
-        return self.auth_code.validate_token_request(request)
-
+        # Hybrid flows can return the id_token from the authorization
+        # endpoint as part of the 'code' response
+        self.register_code_modifier(self.add_token)
+        self.register_code_modifier(self.add_id_token)
+        self.register_token_modifier(self.add_id_token)

--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -335,7 +335,7 @@ class OpenIDConnectAuthCode(OpenIDConnectBase):
     def __init__(self, request_validator=None, **kwargs):
         self.proxy_target = AuthorizationCodeGrant(
             request_validator=request_validator, **kwargs)
-        self.register_authorization_validator(
+        self.custom_validators.post_auth.append(
             self.openid_authorization_validator)
         self.register_token_modifier(self.add_id_token)
 
@@ -346,9 +346,9 @@ class OpenIDConnectImplicit(OpenIDConnectBase):
             request_validator=request_validator, **kwargs)
         self.register_response_type('id_token')
         self.register_response_type('id_token token')
-        self.register_authorization_validator(
+        self.custom_validators.post_auth.append(
             self.openid_authorization_validator)
-        self.register_authorization_validator(
+        self.custom_validators.post_auth.append(
             self.openid_implicit_authorization_validator)
         self.register_token_modifier(self.add_id_token)
 
@@ -362,7 +362,7 @@ class OpenIDConnectHybrid(OpenIDConnectBase):
         self.register_response_type('code id_token')
         self.register_response_type('code token')
         self.register_response_type('code id_token token')
-        self.register_authorization_validator(
+        self.custom_validators.post_auth.append(
             self.openid_authorization_validator)
         # Hybrid flows can return the id_token from the authorization
         # endpoint as part of the 'code' response

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -76,7 +76,7 @@ class RefreshTokenGrant(GrantTypeBase):
         if request.grant_type != 'refresh_token':
             raise errors.UnsupportedGrantTypeError(request=request)
 
-        for validator in self._token_validators_run_before_standard_ones:
+        for validator in self.custom_validators.pre_token:
             validator(request)
 
         if request.refresh_token is None:
@@ -127,5 +127,5 @@ class RefreshTokenGrant(GrantTypeBase):
         else:
             request.scopes = original_scopes
 
-        for validator in self._token_validators_run_after_standard_ones:
+        for validator in self.custom_validators.post_token:
             validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -22,13 +22,13 @@ class RefreshTokenGrant(GrantTypeBase):
     .. _`Refresh token grant`: http://tools.ietf.org/html/rfc6749#section-6
     """
 
-    def __init__(self, request_validator=None, issue_new_refresh_tokens=True):
-        self.request_validator = request_validator or RequestValidator()
-        self.issue_new_refresh_tokens = issue_new_refresh_tokens
-        self._token_modifiers = []
-
-    def register_token_modifier(self, modifier):
-        self._token_modifiers.append(modifier)
+    def __init__(self, request_validator=None,
+                 issue_new_refresh_tokens=True,
+                 **kwargs):
+        super(RefreshTokenGrant, self).__init__(
+            request_validator,
+            issue_new_refresh_tokens=issue_new_refresh_tokens,
+            **kwargs)
 
     def create_token_response(self, request, token_handler):
         """Create a new access token from a refresh_token.
@@ -75,6 +75,9 @@ class RefreshTokenGrant(GrantTypeBase):
         # REQUIRED. Value MUST be set to "refresh_token".
         if request.grant_type != 'refresh_token':
             raise errors.UnsupportedGrantTypeError(request=request)
+
+        for validator in self._token_validators_run_before_standard_ones:
+            validator(request)
 
         if request.refresh_token is None:
             raise errors.InvalidRequestError(
@@ -123,3 +126,6 @@ class RefreshTokenGrant(GrantTypeBase):
                 raise errors.InvalidScopeError(request=request)
         else:
             request.scopes = original_scopes
+
+        for validator in self._token_validators_run_after_standard_ones:
+            validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -70,18 +70,6 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
     .. _`Resource Owner Password Credentials Grant`: http://tools.ietf.org/html/rfc6749#section-4.3
     """
 
-    def __init__(self, request_validator=None, refresh_token=True):
-        """
-        If the refresh_token keyword argument is False, do not return
-        a refresh token in the response.
-        """
-        self.request_validator = request_validator or RequestValidator()
-        self.refresh_token = refresh_token
-        self._token_modifiers = []
-
-    def register_token_modifier(self, modifier):
-        self._token_modifiers.append(modifier)
-
     def create_token_response(self, request, token_handler):
         """Return token or error in json format.
 
@@ -168,6 +156,9 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
         .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
         """
+        for validator in self._token_validators_run_before_standard_ones:
+            validator(request)
+
         for param in ('grant_type', 'username', 'password'):
             if not getattr(request, param, None):
                 raise errors.InvalidRequestError(
@@ -201,3 +192,6 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         if request.client:
             request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
+
+        for validator in self._token_validators_run_after_standard_ones:
+            validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -156,7 +156,7 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
         .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
         """
-        for validator in self._token_validators_run_before_standard_ones:
+        for validator in self.custom_validators.pre_token:
             validator(request)
 
         for param in ('grant_type', 'username', 'password'):
@@ -193,5 +193,5 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
             request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
 
-        for validator in self._token_validators_run_after_standard_ones:
+        for validator in self.custom_validators.post_token:
             validator(request)

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -32,15 +32,20 @@ class AuthorizationCodeGrantTest(TestCase):
         request.client.client_id = 'mocked'
         return True
 
-    def test_custom_auth_validators(self):
+    def setup_validators(self):
         self.authval1, self.authval2 = mock.Mock(), mock.Mock()
         self.authval1.return_value = {}
         self.authval2.return_value = {}
         self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
-        self.auth.register_token_validator(self.tknval1, after_standard=False)
-        self.auth.register_token_validator(self.tknval2, after_standard=True)
-        self.auth.register_authorization_validator(self.authval1, after_standard=False)
-        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+        self.tknval1.return_value = None
+        self.tknval2.return_value = None
+        self.auth.custom_validators.pre_token.append(self.tknval1)
+        self.auth.custom_validators.post_token.append(self.tknval2)
+        self.auth.custom_validators.pre_auth.append(self.authval1)
+        self.auth.custom_validators.post_auth.append(self.authval2)
+
+    def test_custom_auth_validators(self):
+        self.setup_validators()
 
         bearer = BearerToken(self.mock_validator)
         self.auth.create_authorization_response(self.request, bearer)
@@ -50,12 +55,7 @@ class AuthorizationCodeGrantTest(TestCase):
         self.assertFalse(self.tknval2.called)
 
     def test_custom_token_validators(self):
-        self.authval1, self.authval2 = mock.Mock(), mock.Mock()
-        self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
-        self.auth.register_token_validator(self.tknval1, after_standard=False)
-        self.auth.register_token_validator(self.tknval2, after_standard=True)
-        self.auth.register_authorization_validator(self.authval1, after_standard=False)
-        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+        self.setup_validators()
 
         bearer = BearerToken(self.mock_validator)
         self.auth.create_token_response(self.request, bearer)

--- a/tests/oauth2/rfc6749/grant_types/test_client_credentials.py
+++ b/tests/oauth2/rfc6749/grant_types/test_client_credentials.py
@@ -22,6 +22,20 @@ class ClientCredentialsGrantTest(TestCase):
         self.auth = ClientCredentialsGrant(
                 request_validator=self.mock_validator)
 
+    def test_custom_token_validators(self):
+        self.authval1, self.authval2 = mock.Mock(), mock.Mock()
+        self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
+        self.auth.register_token_validator(self.tknval1, after_standard=False)
+        self.auth.register_token_validator(self.tknval2, after_standard=True)
+        self.auth.register_authorization_validator(self.authval1, after_standard=False)
+        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+        bearer = BearerToken(self.mock_validator)
+        self.auth.create_token_response(self.request, bearer)
+        self.assertTrue(self.tknval1.called)
+        self.assertTrue(self.tknval2.called)
+        self.assertFalse(self.authval1.called)
+        self.assertFalse(self.authval2.called)
+
     def test_create_token_response(self):
         bearer = BearerToken(self.mock_validator)
         headers, body, status_code = self.auth.create_token_response(

--- a/tests/oauth2/rfc6749/grant_types/test_client_credentials.py
+++ b/tests/oauth2/rfc6749/grant_types/test_client_credentials.py
@@ -22,19 +22,30 @@ class ClientCredentialsGrantTest(TestCase):
         self.auth = ClientCredentialsGrant(
                 request_validator=self.mock_validator)
 
+    def test_custom_auth_validators_unsupported(self):
+        authval1, authval2 = mock.Mock(), mock.Mock()
+        expected = ('ClientCredentialsGrant does not support authorization '
+                    'validators. Use token validators instead.')
+        with self.assertRaises(ValueError) as caught:
+            ClientCredentialsGrant(self.mock_validator, pre_auth=[authval1])
+        self.assertEqual(caught.exception.args[0], expected)
+        with self.assertRaises(ValueError) as caught:
+            ClientCredentialsGrant(self.mock_validator, post_auth=[authval2])
+        self.assertEqual(caught.exception.args[0], expected)
+        with self.assertRaises(AttributeError):
+            self.auth.custom_validators.pre_auth.append(authval1)
+        with self.assertRaises(AttributeError):
+            self.auth.custom_validators.pre_auth.append(authval2)
+
     def test_custom_token_validators(self):
-        self.authval1, self.authval2 = mock.Mock(), mock.Mock()
-        self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
-        self.auth.register_token_validator(self.tknval1, after_standard=False)
-        self.auth.register_token_validator(self.tknval2, after_standard=True)
-        self.auth.register_authorization_validator(self.authval1, after_standard=False)
-        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+        tknval1, tknval2 = mock.Mock(), mock.Mock()
+        self.auth.custom_validators.pre_token.append(tknval1)
+        self.auth.custom_validators.post_token.append(tknval2)
+
         bearer = BearerToken(self.mock_validator)
         self.auth.create_token_response(self.request, bearer)
-        self.assertTrue(self.tknval1.called)
-        self.assertTrue(self.tknval2.called)
-        self.assertFalse(self.authval1.called)
-        self.assertFalse(self.authval2.called)
+        self.assertTrue(tknval1.called)
+        self.assertTrue(tknval2.called)
 
     def test_create_token_response(self):
         bearer = BearerToken(self.mock_validator)

--- a/tests/oauth2/rfc6749/grant_types/test_implicit.py
+++ b/tests/oauth2/rfc6749/grant_types/test_implicit.py
@@ -47,10 +47,10 @@ class ImplicitGrantTest(TestCase):
             val.return_value = {}
         for val in (self.tknval1, self.tknval2):
             val.return_value = None
-        self.auth.register_token_validator(self.tknval1, after_standard=False)
-        self.auth.register_token_validator(self.tknval2, after_standard=True)
-        self.auth.register_authorization_validator(self.authval1, after_standard=False)
-        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+        self.auth.custom_validators.pre_token.append(self.tknval1)
+        self.auth.custom_validators.post_token.append(self.tknval2)
+        self.auth.custom_validators.pre_auth.append(self.authval1)
+        self.auth.custom_validators.post_auth.append(self.authval2)
 
         bearer = BearerToken(self.mock_validator)
         self.auth.create_token_response(self.request, bearer)

--- a/tests/oauth2/rfc6749/grant_types/test_implicit.py
+++ b/tests/oauth2/rfc6749/grant_types/test_implicit.py
@@ -40,5 +40,24 @@ class ImplicitGrantTest(TestCase):
         h, b, s = self.auth.create_token_response(self.request, bearer)
         self.assertURLEqual(h['Location'], correct_uri)
 
+    def test_custom_validators(self):
+        self.authval1, self.authval2 = mock.Mock(), mock.Mock()
+        self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
+        for val in (self.authval1, self.authval2):
+            val.return_value = {}
+        for val in (self.tknval1, self.tknval2):
+            val.return_value = None
+        self.auth.register_token_validator(self.tknval1, after_standard=False)
+        self.auth.register_token_validator(self.tknval2, after_standard=True)
+        self.auth.register_authorization_validator(self.authval1, after_standard=False)
+        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+
+        bearer = BearerToken(self.mock_validator)
+        self.auth.create_token_response(self.request, bearer)
+        self.assertTrue(self.tknval1.called)
+        self.assertTrue(self.tknval2.called)
+        self.assertTrue(self.authval1.called)
+        self.assertTrue(self.authval2.called)
+
     def test_error_response(self):
         pass

--- a/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
+++ b/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
@@ -36,20 +36,30 @@ class RefreshTokenGrantTest(TestCase):
         self.assertIn('expires_in', token)
         self.assertEqual(token['scope'], 'foo')
 
+    def test_custom_auth_validators_unsupported(self):
+        authval1, authval2 = mock.Mock(), mock.Mock()
+        expected = ('RefreshTokenGrant does not support authorization '
+                    'validators. Use token validators instead.')
+        with self.assertRaises(ValueError) as caught:
+            RefreshTokenGrant(self.mock_validator, pre_auth=[authval1])
+        self.assertEqual(caught.exception.args[0], expected)
+        with self.assertRaises(ValueError) as caught:
+            RefreshTokenGrant(self.mock_validator, post_auth=[authval2])
+        self.assertEqual(caught.exception.args[0], expected)
+        with self.assertRaises(AttributeError):
+            self.auth.custom_validators.pre_auth.append(authval1)
+        with self.assertRaises(AttributeError):
+            self.auth.custom_validators.pre_auth.append(authval2)
+
     def test_custom_token_validators(self):
-        self.authval1, self.authval2 = mock.Mock(), mock.Mock()
-        self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
-        self.auth.register_token_validator(self.tknval1, after_standard=False)
-        self.auth.register_token_validator(self.tknval2, after_standard=True)
-        self.auth.register_authorization_validator(self.authval1, after_standard=False)
-        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+        tknval1, tknval2 = mock.Mock(), mock.Mock()
+        self.auth.custom_validators.pre_token.append(tknval1)
+        self.auth.custom_validators.post_token.append(tknval2)
 
         bearer = BearerToken(self.mock_validator)
         self.auth.create_token_response(self.request, bearer)
-        self.assertTrue(self.tknval1.called)
-        self.assertTrue(self.tknval2.called)
-        self.assertFalse(self.authval1.called)
-        self.assertFalse(self.authval2.called)
+        self.assertTrue(tknval1.called)
+        self.assertTrue(tknval2.called)
 
     def test_create_token_inherit_scope(self):
         self.request.scope = None

--- a/tests/oauth2/rfc6749/grant_types/test_resource_owner_password.py
+++ b/tests/oauth2/rfc6749/grant_types/test_resource_owner_password.py
@@ -89,6 +89,21 @@ class ResourceOwnerPasswordCredentialsGrantTest(TestCase):
         self.assertEqual(status_code, 401)
         self.assertEqual(self.mock_validator.save_token.call_count, 0)
 
+    def test_custom_token_validators(self):
+        self.authval1, self.authval2 = mock.Mock(), mock.Mock()
+        self.tknval1, self.tknval2 = mock.Mock(), mock.Mock()
+        self.auth.register_token_validator(self.tknval1, after_standard=False)
+        self.auth.register_token_validator(self.tknval2, after_standard=True)
+        self.auth.register_authorization_validator(self.authval1, after_standard=False)
+        self.auth.register_authorization_validator(self.authval2, after_standard=True)
+
+        bearer = BearerToken(self.mock_validator)
+        self.auth.create_token_response(self.request, bearer)
+        self.assertTrue(self.tknval1.called)
+        self.assertTrue(self.tknval2.called)
+        self.assertFalse(self.authval1.called)
+        self.assertFalse(self.authval2.called)
+
     def test_error_response(self):
         pass
 


### PR DESCRIPTION
This changeset is an attempt to improve and standardize the validator registration hooks introduced with the OpenIDConnect changes.

- Moves custom validator registration up onto the `GrantTypeBase` class and removes those methods from the subclass grants.
- DRYs up the OpenIDConnect grant type classes to be more of thin proxies onto the standard OAuth2 grant classes.
- Adds the ability to register validators that run either before or after the standard validation methods.
- Adds custom validator invocations to `ClientCredentialsGrant`, `RefreshTokenGrant` and `ResourceOwnerPasswordCredentialsGrant`.
- Adds tests for custom validators.