### PR TITLE
Public clients should be validated when revoking tokens

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -122,7 +122,11 @@ class RevocationEndpoint(BaseEndpoint):
 
         if self.request_validator.client_authentication_required(request):
             if not self.request_validator.authenticate_client(request):
+                log.debug('Client authentication failed, %r.', request)
                 raise InvalidClientError(request=request)
+        elif not self.request_validator.authenticate_client_id(request.client_id, request):
+            log.debug('Client authentication failed, %r.', request)
+            raise InvalidClientError(request=request) 
 
         if (request.token_type_hint and
                 request.token_type_hint in self.valid_token_types and

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -14,6 +14,7 @@ class RevocationEndpointTest(TestCase):
 
     def setUp(self):
         self.validator = MagicMock(wraps=RequestValidator())
+        self.validator.client_authentication_required.return_value = True
         self.validator.authenticate_client.return_value = True
         self.validator.revoke_token.return_value = True
         self.endpoint = RevocationEndpoint(self.validator)
@@ -40,10 +41,20 @@ class RevocationEndpointTest(TestCase):
         self.assertEqual(h, {})
         self.assertEqual(b, '')
         self.assertEqual(s, 200)
-    
-    def test_revoke_token_without_client_authentication(self):
+
+    def test_revoke_token_client_authentication_failed(self):
+        self.validator.authenticate_client.return_value = False
+        body = urlencode([('token', 'foo'),
+                          ('token_type_hint', 'access_token')])
+        h, b, s = self.endpoint.create_revocation_response(self.uri,
+                headers=self.headers, body=body)
+        self.assertEqual(h, {})
+        self.assertEqual(loads(b)['error'], 'invalid_client')
+        self.assertEqual(s, 401)
+
+    def test_revoke_token_public_client_authentication(self):
         self.validator.client_authentication_required.return_value = False
-        self.validator.authenticate_client.return_value = False        
+        self.validator.authenticate_client_id.return_value = True
         for token_type in ('access_token', 'refresh_token', 'invalid'):
             body = urlencode([('token', 'foo'),
                               ('token_type_hint', token_type)])
@@ -53,17 +64,16 @@ class RevocationEndpointTest(TestCase):
             self.assertEqual(b, None)
             self.assertEqual(s, 200)
 
-    def test_revoke_token_without_client_authentication(self):
+    def test_revoke_token_public_client_authentication_failed(self):
         self.validator.client_authentication_required.return_value = False
-        self.validator.authenticate_client.return_value = False
-        for token_type in ('access_token', 'refresh_token', 'invalid'):
-            body = urlencode([('token', 'foo'),
-                              ('token_type_hint', token_type)])
-            h, b, s = self.endpoint.create_revocation_response(self.uri,
-                    headers=self.headers, body=body)
-            self.assertEqual(h, {})
-            self.assertEqual(b, '')
-            self.assertEqual(s, 200)
+        self.validator.authenticate_client_id.return_value = False
+        body = urlencode([('token', 'foo'),
+                          ('token_type_hint', 'access_token')])
+        h, b, s = self.endpoint.create_revocation_response(self.uri,
+                headers=self.headers, body=body)
+        self.assertEqual(h, {})
+        self.assertEqual(loads(b)['error'], 'invalid_client')
+        self.assertEqual(s, 401)
 
     def test_revoke_with_callback(self):
         endpoint = RevocationEndpoint(self.validator, enable_jsonp=True)

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -61,7 +61,7 @@ class RevocationEndpointTest(TestCase):
             h, b, s = self.endpoint.create_revocation_response(self.uri,
                     headers=self.headers, body=body)
             self.assertEqual(h, {})
-            self.assertEqual(b, None)
+            self.assertEqual(b, '')
             self.assertEqual(s, 200)
 
     def test_revoke_token_public_client_authentication_failed(self):


### PR DESCRIPTION
According to [RC7009 Section 2.1](https://tools.ietf.org/html/rfc7009#section-2.1), a client should include authentication credentials when revoking its tokens. As discussed in #339, this is not make sense for public clients. However, in that case, the public client should still be checked that is infact a public client (`authenticate_client_id`).

I also fixed a what appears to be a bad merge (`test_revoke_token_without_client_authentication` was defined twice), which is why the diff is a little messy.