### PR TITLE
Fixes bug with 'prompt' parameter

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -270,10 +270,15 @@ class OpenIDConnectBase(GrantTypeBase):
             msg = "Session user does not match client supplied user."
             raise LoginRequired(request=request, description=msg)
 
+        prompt = []
+        if request.prompt:
+            prompt = request.prompt
+            if hasattr(prompt, 'split'):
+                prompt = prompt.split()
 
         request_info = {
             'display': request.display,
-            'prompt': request.prompt.split() if request.prompt else [],
+            'prompt': prompt,
             'ui_locales': request.ui_locales.split() if request.ui_locales else [],
             'id_token_hint': request.id_token_hint,
             'login_hint': request.login_hint,

--- a/tests/oauth2/rfc6749/endpoints/test_prompt_handling.py
+++ b/tests/oauth2/rfc6749/endpoints/test_prompt_handling.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, unicode_literals
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
+import mock
+
+from ....unittest import TestCase
+from oauthlib.oauth2.rfc6749.tokens import BearerToken
+from oauthlib.oauth2.rfc6749.grant_types import OpenIDConnectAuthCode
+from oauthlib.oauth2.rfc6749.endpoints.authorization import AuthorizationEndpoint
+
+class OpenIDConnectEndpointTest(TestCase):
+
+    def setUp(self):
+        self.mock_validator = mock.MagicMock()
+        self.mock_validator.authenticate_client.side_effect = self.set_client
+        grant = OpenIDConnectAuthCode(request_validator=self.mock_validator)
+        bearer = BearerToken(self.mock_validator)
+        self.endpoint = AuthorizationEndpoint(grant, bearer,
+                                              response_types={'code': grant})
+        params = {
+            'prompt': 'consent',
+            'state': 'abc',
+            'redirect_uri': 'https://a.b/cb',
+            'response_type': 'code',
+            'client_id': 'abcdef',
+            'scope': 'hello openid'
+        }
+        self.url = 'http://a.b/path?' + urlencode(params)
+
+    def set_client(self, request):
+        request.client = mock.MagicMock()
+        request.client.client_id = 'mocked'
+        return True
+
+    @mock.patch('oauthlib.common.generate_token')
+    def test_authorization_endpoint_handles_prompt(self, generate_token):
+        generate_token.return_value = "MOCK_CODE"
+        # In the GET view:
+        scopes, creds = self.endpoint.validate_authorization_request(self.url)
+        # In the POST view:
+        creds['scopes'] = scopes
+        h, b, s = self.endpoint.create_authorization_response(self.url,
+                                                        credentials=creds)
+        expected = 'https://a.b/cb?state=abc&code=MOCK_CODE'
+        self.assertURLEqual(h['Location'], expected)
+        self.assertEqual(b, None)
+        self.assertEqual(s, 302)


### PR DESCRIPTION
This changeset fixes a bug with the OpenIDConnect `prompt=` parameter that occurs in the second invocation of the `openid_authorization_validator()` during a POST to the authorization endpoint. If `credentials['prompt']` is already a list, then calling `split()` triggers an `AttributeError`

This is a deliberately conservative fix that just avoids trying to `split()` twice. It's possible that this bug points to a deeper problem with this approach (are we sure we should be splitting `prompt` when returning the `request_info`?) in the OIDC parameter handling.  

Is this same bug likely to occur with the `ui_locales` parameter?