### PR TITLE
Add universal wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
See http://pythonwheels.com/

Python wheels provide faster installation for pure Python packages. To upload a
wheel to PyPI use the command:

python setup.py sdist bdist_wheel upload