### PR TITLE
Redirect errors according to OIDC's response_mode.

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -54,12 +54,14 @@ class OAuth2Error(Exception):
             self.client_id = request.client_id
             self.scopes = request.scopes
             self.response_type = request.response_type
+            self.response_mode = request.response_mode
             self.grant_type = request.grant_type
             if not state:
                 self.state = request.state
 
     def in_uri(self, uri):
-        return add_params_to_uri(uri, self.twotuples)
+        return add_params_to_uri(uri, self.twotuples,
+                                 fragment=self.response_mode == "fragment")
 
     @property
     def twotuples(self):

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -210,7 +210,10 @@ class AuthorizationCodeGrant(GrantTypeBase):
         except errors.OAuth2Error as e:
             log.debug('Client error during validation of %r. %r.', request, e)
             request.redirect_uri = request.redirect_uri or self.error_uri
-            return {'Location': common.add_params_to_uri(request.redirect_uri, e.twotuples)}, None, 302
+            redirect_uri = common.add_params_to_uri(
+                request.redirect_uri, e.twotuples,
+                fragment=request.response_mode == "fragment")
+            return {'Location': redirect_uri}, None, 302
 
         grant = self.create_authorization_code(request)
         for modifier in self._code_modifiers:


### PR DESCRIPTION
OIDC errors should be redirected as indicated by the `response_mode` parameter. This PR attempts to do that without breaking OAuth2 flows.