### PR TITLE
Update proxy keys on CaseInsensitiveDict.update()

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -354,6 +354,11 @@ class CaseInsensitiveDict(dict):
         super(CaseInsensitiveDict, self).__setitem__(k, v)
         self.proxy[k.lower()] = k
 
+    def update(self, *args, **kwargs):
+        super(CaseInsensitiveDict, self).update(*args, **kwargs)
+        for k in dict(*args, **kwargs):
+            self.proxy[k.lower()] = k
+
 
 class Request(object):
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -228,3 +228,8 @@ class CaseInsensitiveDictTest(TestCase):
         del cid['c']
         self.assertEqual(cid['A'], 'b')
         self.assertEqual(cid['a'], 'b')
+
+    def test_update(self):
+        cid = CaseInsensitiveDict({})
+        cid.update({'KeY': 'value'})
+        self.assertEqual(cid['kEy'], 'value')


### PR DESCRIPTION
Proxy keys weren't being filled in on CaseInsensitiveDict.update(), causing lookups to fail.