### PR TITLE
Hybrid response types should be fragment-encoded

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -371,6 +371,8 @@ class OpenIDConnectHybrid(OpenIDConnectBase):
 
         self.proxy_target = AuthorizationCodeGrant(
             request_validator=request_validator, **kwargs)
+        # All hybrid response types should be fragment-encoded.
+        self.proxy_target.default_response_mode = "fragment"
         self.register_response_type('code id_token')
         self.register_response_type('code token')
         self.register_response_type('code id_token token')

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -66,6 +66,7 @@ class AuthorizationCodeGrantTest(TestCase):
 
     def test_create_authorization_grant(self):
         bearer = BearerToken(self.mock_validator)
+        self.request.response_mode = 'query'
         h, b, s = self.auth.create_authorization_response(self.request, bearer)
         grant = dict(Request(h['Location']).uri_query_params)
         self.assertIn('code', grant)
@@ -76,6 +77,7 @@ class AuthorizationCodeGrantTest(TestCase):
     def test_create_authorization_grant_state(self):
         self.request.state = 'abc'
         self.request.redirect_uri = None
+        self.request.response_mode = 'query'
         self.mock_validator.get_default_redirect_uri.return_value = 'https://a.b/cb'
         bearer = BearerToken(self.mock_validator)
         h, b, s = self.auth.create_authorization_response(self.request, bearer)
@@ -91,6 +93,7 @@ class AuthorizationCodeGrantTest(TestCase):
     def test_create_authorization_response(self, generate_token):
         generate_token.return_value = 'abc'
         bearer = BearerToken(self.mock_validator)
+        self.request.response_mode = 'query'
         h, b, s = self.auth.create_authorization_response(self.request, bearer)
         self.assertURLEqual(h['Location'], 'https://a.b/cb?code=abc')
         self.request.response_mode = 'fragment'

--- a/tests/oauth2/rfc6749/grant_types/test_openid_connect.py
+++ b/tests/oauth2/rfc6749/grant_types/test_openid_connect.py
@@ -16,14 +16,14 @@ from .test_implicit import ImplicitGrantTest
 
 
 class OpenIDAuthCodeInterferenceTest(AuthorizationCodeGrantTest):
-    """Test that OpenID don't interfer with normal OAuth 2 flows."""
+    """Test that OpenID don't interfere with normal OAuth 2 flows."""
 
     def setUp(self):
         super(OpenIDAuthCodeInterferenceTest, self).setUp()
         self.auth = OpenIDConnectAuthCode(request_validator=self.mock_validator)
 
 class OpenIDImplicitInterferenceTest(ImplicitGrantTest):
-    """Test that OpenID don't interfer with normal OAuth 2 flows."""
+    """Test that OpenID don't interfere with normal OAuth 2 flows."""
 
     def setUp(self):
         super(OpenIDImplicitInterferenceTest, self).setUp()
@@ -31,7 +31,7 @@ class OpenIDImplicitInterferenceTest(ImplicitGrantTest):
 
 
 class OpenIDHybridInterferenceTest(AuthorizationCodeGrantTest):
-    """Test that OpenID don't interfer with normal OAuth 2 flows."""
+    """Test that OpenID don't interfere with normal OAuth 2 flows."""
 
     def setUp(self):
         super(OpenIDHybridInterferenceTest, self).setUp()
@@ -75,8 +75,15 @@ class OpenIDAuthCodeTest(TestCase):
 
         generate_token.return_value = 'abc'
         bearer = BearerToken(self.mock_validator)
+        self.request.response_mode = 'query'
         h, b, s = self.auth.create_authorization_response(self.request, bearer)
         self.assertURLEqual(h['Location'], self.url_query)
+        self.assertEqual(b, None)
+        self.assertEqual(s, 302)
+
+        self.request.response_mode = 'fragment'
+        h, b, s = self.auth.create_authorization_response(self.request, bearer)
+        self.assertURLEqual(h['Location'], self.url_fragment, parse_fragment=True)
         self.assertEqual(b, None)
         self.assertEqual(s, 302)
 
@@ -96,6 +103,7 @@ class OpenIDAuthCodeTest(TestCase):
         self.assertEqual(b, None)
         self.assertEqual(s, 302)
 
+        self.request.response_mode = 'query'
         self.request.id_token_hint = 'me@email.com'
         h, b, s = self.auth.create_authorization_response(self.request, bearer)
         self.assertURLEqual(h['Location'], self.url_query)


### PR DESCRIPTION
According to the [multiple response types specification](http://openid.net/specs/oauth-v2-multiple-response-types-1_0-03.html#anchor5) all hybrid response types should return fragment-encoded responses.

However, according to the unit tests there might be some side effects.