### PR TITLE
Changed all implicit imports * with explicit classes imports

### DIFF
--- a/oauthlib/oauth1/__init__.py
+++ b/oauthlib/oauth1/__init__.py
@@ -16,4 +16,4 @@ from .rfc5849.request_validator import RequestValidator
 from .rfc5849.endpoints import RequestTokenEndpoint, AuthorizationEndpoint
 from .rfc5849.endpoints import AccessTokenEndpoint, ResourceEndpoint
 from .rfc5849.endpoints import SignatureOnlyEndpoint, WebApplicationServer
-from .rfc5849.errors import *
+from .rfc5849.errors import InsecureTransportError, InvalidClientError, InvalidRequestError, InvalidSignatureMethodError, OAuth1Error

--- a/oauthlib/oauth2/__init__.py
+++ b/oauthlib/oauth2/__init__.py
@@ -23,7 +23,7 @@ from .rfc6749.endpoints import WebApplicationServer
 from .rfc6749.endpoints import MobileApplicationServer
 from .rfc6749.endpoints import LegacyApplicationServer
 from .rfc6749.endpoints import BackendApplicationServer
-from .rfc6749.errors import *
+from .rfc6749.errors import AccessDeniedError, AccountSelectionRequried, ConsentRequired, FatalClientError, FatalOpenIDClientError, InsecureTransportError, InteractionRequired, InvalidClientError, InvalidClientIdError, InvalidGrantError, InvalidRedirectURIError, InvalidRequestError, InvalidRequestFatalError, InvalidScopeError, LoginRequired, MismatchingRedirectURIError, MismatchingStateError, MissingClientIdError, MissingCodeError, MissingRedirectURIError, MissingResponseTypeError, MissingTokenError, MissingTokenTypeError, OAuth2Error, OpenIDClientError, ServerError, TemporarilyUnavailableError, TokenExpiredError, UnauthorizedClientError, UnsupportedGrantTypeError, UnsupportedResponseTypeError, UnsupportedTokenTypeError
 from .rfc6749.grant_types import AuthorizationCodeGrant
 from .rfc6749.grant_types import ImplicitGrant
 from .rfc6749.grant_types import ResourceOwnerPasswordCredentialsGrant

--- a/oauthlib/oauth2/rfc6749/clients/__init__.py
+++ b/oauthlib/oauth2/rfc6749/clients/__init__.py
@@ -8,7 +8,7 @@ for consuming OAuth 2.0 RFC6749.
 """
 from __future__ import absolute_import, unicode_literals
 
-from .base import Client
+from .base import Client, AUTH_HEADER, URI_QUERY, BODY
 from .web_application import WebApplicationClient
 from .mobile_application import MobileApplicationClient
 from .legacy_application import LegacyApplicationClient

--- a/oauthlib/oauth2/rfc6749/clients/__init__.py
+++ b/oauthlib/oauth2/rfc6749/clients/__init__.py
@@ -8,7 +8,7 @@ for consuming OAuth 2.0 RFC6749.
 """
 from __future__ import absolute_import, unicode_literals
 
-from .base import *
+from .base import Client
 from .web_application import WebApplicationClient
 from .mobile_application import MobileApplicationClient
 from .legacy_application import LegacyApplicationClient


### PR DESCRIPTION
While integrating oauthlib with a Jython application we've found that Jython 2.7.0 has issues with `import *`.

This way of importing is in general strongly discouraged due to namespace pollution and unattended conflicts which could happen.

We've found only 3 occurrences of import * and we fixed all of them:
```
$ grep -R "from .* import \*" *
oauth1/__init__.py:from .rfc5849.errors import *
oauth2/__init__.py:from .rfc6749.errors import *
oauth2/rfc6749/clients/__init__.py:from .base import *
```

Please consider merging this PR and include in the next release.

Thank you.