### PR TITLE
Add anchors to valid chars in a redirect_uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ coverage
 # Sphinx
 docs/_build
 docs/_static
+
+.cache

--- a/oauthlib/uri_validate.py
+++ b/oauthlib/uri_validate.py
@@ -33,8 +33,8 @@ gen_delims = r"(?: : | / | \? | \# | \[ | \] | @ )"
 sub_delims = r"""(?: ! | \$ | & | ' | \( | \) |
                      \* | \+ | , | ; | = )"""
 
-#   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-pchar = r"(?: %(unreserved)s | %(pct_encoded)s | %(sub_delims)s | : | @ )" % locals(
+#   pchar         = unreserved / pct-encoded / sub-delims / "#" / ":" / "@"
+pchar = r"(?: %(unreserved)s | %(pct_encoded)s | %(sub_delims)s | \# | : | @ )" % locals(
 )
 
 #   reserved      = gen-delims / sub-delims

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 pyjwt==1.0.0
 blinker==1.3
 cryptography>=0.8.1
+contextlib2==0.5.4
+testscenarios==0.5.0
+mock==2.0.0
+testresources==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 pyjwt==1.0.0
 blinker==1.3
 cryptography>=0.8.1
-contextlib2==0.5.4
-testscenarios==0.5.0
-mock==2.0.0
-testresources==2.0.1

--- a/tests/oauth2/rfc6749/test_utils.py
+++ b/tests/oauth2/rfc6749/test_utils.py
@@ -110,7 +110,7 @@ class UtilsTests(TestCase):
 
 
 class TestUrlValidation(TestCase):
-    def test_basic_urls(self):
+    def test_good_urls(self):
         valid_urls = ["https://www.zombo.com",
                 "https://google.com",
                 "http://localhost:31337",
@@ -119,6 +119,7 @@ class TestUrlValidation(TestCase):
         for url in valid_urls:
             self.assertIsNotNone(is_absolute_uri(url))
 
+    def test_bad_urls(self):
         invalid_urls = ["asdfasdf",
                 "://www.zombo.com"]
         

--- a/tests/oauth2/rfc6749/test_utils.py
+++ b/tests/oauth2/rfc6749/test_utils.py
@@ -10,6 +10,7 @@ from oauthlib.oauth2.rfc6749.utils import generate_age
 from oauthlib.oauth2.rfc6749.utils import is_secure_transport
 from oauthlib.oauth2.rfc6749.utils import params_from_uri
 from oauthlib.oauth2.rfc6749.utils import list_to_scope, scope_to_list
+from oauthlib.uri_validate import is_absolute_uri
 
 
 class ScopeObject:
@@ -107,4 +108,20 @@ class UtilsTests(TestCase):
         self.assertEqual(sorted(set_list), sorted(string_list_scopes))
 
 
+
+class TestUrlValidation(TestCase):
+    def test_basic_urls(self):
+        valid_urls = ["https://www.zombo.com",
+                "https://google.com",
+                "http://localhost:31337",
+                "https://www.zombo.com/#/angular_crap"] 
+
+        for url in valid_urls:
+            self.assertIsNotNone(is_absolute_uri(url))
+
+        invalid_urls = ["asdfasdf",
+                "://www.zombo.com"]
+        
+        for url in invalid_urls:
+            self.assertIsNone(is_absolute_uri(url), url)
 


### PR DESCRIPTION
@thedrow @bjmc Hey guys, looks like there are some  problems validating redirect_uris that have anchors in unexpected places (eg angular uris).

I extended the regex and added a really basic test.

thoughts?