### PR TITLE
added "{}[]" to urlencoded always_safe

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -109,7 +109,7 @@ def decode_params_utf8(params):
     return decoded
 
 
-urlencoded = set(always_safe) | set('=&;:%+~,*@!()/?')
+urlencoded = set(always_safe) | set('{}[]=&;:%+~,*@!()/?')
 
 
 def urldecode(query):


### PR DESCRIPTION
This fixed an issue when trying to pass filter parameters while using flask-oauthlib with https://github.com/miLibris/flask-rest-jsonapi