### PR TITLE
redirect_uri mismatch

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -424,7 +424,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
                                                            request.redirect_uri, request.client):
             log.debug('Redirect_uri (%r) invalid for client %r (%r).',
                       request.redirect_uri, request.client_id, request.client)
-            raise errors.AccessDeniedError(request=request)
+            raise errors.InvalidRedirectURIError(request=request)
 
         for validator in self.custom_validators.post_token:
             validator(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -424,7 +424,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
                                                            request.redirect_uri, request.client):
             log.debug('Redirect_uri (%r) invalid for client %r (%r).',
                       request.redirect_uri, request.client_id, request.client)
-            raise errors.InvalidRedirectURIError(request=request)
+            raise errors.MismatchingRedirectURIError(request=request)
 
         for validator in self.custom_validators.post_token:
             validator(request)

--- a/tests/oauth2/rfc6749/endpoints/test_credentials_preservation.py
+++ b/tests/oauth2/rfc6749/endpoints/test_credentials_preservation.py
@@ -77,7 +77,7 @@ class PreservationTest(TestCase):
         code = get_query_credentials(h['Location'])['code'][0]
         _, body, _ = self.web.create_token_response(token_uri,
                 body='grant_type=authorization_code&code=%s' % code)
-        self.assertEqual(json.loads(body)['error'], 'access_denied')
+        self.assertEqual(json.loads(body)['error'], 'invalid_request')
 
         # implicit grant
         h, _, s = self.mobile.create_authorization_response(

--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -240,7 +240,7 @@ class ErrorResponseTest(TestCase):
         # Authorization code grant
         _, body, _ = self.web.create_token_response(token_uri,
                 body='grant_type=authorization_code&code=foo')
-        self.assertEqual('access_denied', json.loads(body)['error'])
+        self.assertEqual('invalid_request', json.loads(body)['error'])
 
     def test_unsupported_response_type(self):
         self.validator.get_default_redirect_uri.return_value = 'https://i.b/cb'

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -186,5 +186,5 @@ class AuthorizationCodeGrantTest(TestCase):
 
     def test_invalid_redirect_uri(self):
         self.mock_validator.confirm_redirect_uri.return_value = False
-        self.assertRaises(errors.AccessDeniedError,
+        self.assertRaises(errors.MismatchingRedirectURIError,
                           self.auth.validate_token_request, self.request)


### PR DESCRIPTION
One of our customers came across this issue. they provided the correct redirect_uri on the auth code request, but then the wrong one on the token request.

the error they receive was a 401 "Access Denied", which is correct, but not descriptive. I could start overriding things up in the stack to add a check, but I feel like a more descriptive error can just come back from here, seeing as how there's already an exception specifically for this.

thoughts? 

/cc @bjmc @thedrow 
