### PR TITLE
Pass through nonce in code flow

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -306,6 +306,7 @@ class OpenIDConnectBase(object):
 
         request_info = {
             'display': request.display,
+            'nonce': request.nonce,
             'prompt': prompt,
             'ui_locales': request.ui_locales.split() if request.ui_locales else [],
             'id_token_hint': request.id_token_hint,
@@ -336,9 +337,7 @@ class OpenIDConnectBase(object):
             desc = 'Request is missing mandatory nonce parameter.'
             raise InvalidRequestError(request=request, description=desc)
 
-        self._inflate_claims(request)
-
-        return {'nonce': request.nonce, 'claims': request.claims}
+        return {}
 
 
 class OpenIDConnectAuthCode(OpenIDConnectBase):

--- a/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/openid_connect.py
@@ -141,6 +141,13 @@ class OpenIDConnectBase(object):
     def openid_authorization_validator(self, request):
         """Perform OpenID Connect specific authorization request validation.
 
+        nonce
+                OPTIONAL. String value used to associate a Client session with
+                an ID Token, and to mitigate replay attacks. The value is
+                passed through unmodified from the Authentication Request to
+                the ID Token. Sufficient entropy MUST be present in the nonce
+                values used to prevent attackers from guessing values
+
         display
                 OPTIONAL. ASCII string value that specifies how the
                 Authorization Server displays the authentication and consent

--- a/tests/oauth2/rfc6749/endpoints/test_openid_connect_params_handling.py
+++ b/tests/oauth2/rfc6749/endpoints/test_openid_connect_params_handling.py
@@ -29,6 +29,8 @@ class OpenIDConnectEndpointTest(TestCase):
                                               response_types={'code': grant})
         params = {
             'prompt': 'consent',
+            'display': 'touch',
+            'nonce': 'abcd',
             'state': 'abc',
             'redirect_uri': 'https://a.b/cb',
             'response_type': 'code',
@@ -71,3 +73,13 @@ class OpenIDConnectEndpointTest(TestCase):
         url = 'http://a.b/path?' + urlencode(params)
         with self.assertRaises(InvalidRequestError):
             self.endpoint.validate_authorization_request(url)
+
+    def test_oidc_params_preservation(self):
+        """
+        Test that the nonce parameter is passed through.
+        """
+        scopes, creds = self.endpoint.validate_authorization_request(self.url)
+
+        self.assertEqual(creds['prompt'], {'consent'})
+        self.assertEqual(creds['nonce'], 'abcd')
+        self.assertEqual(creds['display'], 'touch')


### PR DESCRIPTION
Nonces are *optional* in `authorization_code` flow, but still should be passed through if the RP provided one.

> If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token

Also the claims parameter appeared to be processed twice.