### PR TITLE
initialization of variable

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -39,6 +39,7 @@ class OAuth2Error(Exception):
 
         request:  Oauthlib Request object
         """
+        self.response_mode = None
         self.description = description or self.description
         message = '(%s) %s' % (self.error, self.description)
         if request:


### PR DESCRIPTION
if `in_uri` is called and `response_mode` is not initialized an exception is raised (happen if used with e.g. Flask_OAuthlib)