### PR TITLE
When deploying a release to PyPI, include the wheel distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ deploy:
   user: ib.lundgren
   password:
     secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
+  distributions: sdist bdist_wheel
   on:
     tags: true
     repo: idan/oauthlib


### PR DESCRIPTION
For Travis CI documentation on including a bdist_wheel distribution, see:

https://docs.travis-ci.com/user/deployment/pypi/#Uploading-different-distributions

Fixes #493

---

I don't have a good way to test this. I'm simply going by the documentation.