### PR TITLE
Add support for HMAC-SHA256 (builds on PR#388)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.0.3 (2015-08-16)
+------------------
+* (Fix) Changed the documented return type of the ```invalidate_request_token()``` method from the RSA key to None since nobody is using the return type.
+* (Enhancement) Added a validator log that will store what the endpoint has computed for debugging and logging purposes (OAuth 1 only for now). 
+
 1.0.2 (2015-08-10)
 ------------------
 * (Fix) Allow client secret to be null for public applications that do not mandate it's specification in the query parameters.

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -10,7 +10,7 @@
 """
 
 __author__ = 'Idan Gazit <idan@gazit.me>'
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 
 import logging

--- a/oauthlib/oauth1/__init__.py
+++ b/oauthlib/oauth1/__init__.py
@@ -9,7 +9,7 @@ and Server classes.
 from __future__ import absolute_import, unicode_literals
 
 from .rfc5849 import Client
-from .rfc5849 import SIGNATURE_HMAC, SIGNATURE_RSA, SIGNATURE_PLAINTEXT
+from .rfc5849 import SIGNATURE_HMAC, SIGNATURE_HMAC_SHA1, SIGNATURE_HMAC_SHA256, SIGNATURE_RSA, SIGNATURE_PLAINTEXT
 from .rfc5849 import SIGNATURE_TYPE_AUTH_HEADER, SIGNATURE_TYPE_QUERY
 from .rfc5849 import SIGNATURE_TYPE_BODY
 from .rfc5849.request_validator import RequestValidator

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -478,20 +478,20 @@ def sign_hmac_sha256_with_client(base_string, client):
 
 
 def sign_hmac_sha256(base_string, client_secret, resource_owner_secret):
-    """**HMAC-SHA1**
+    """**HMAC-SHA256**
 
-    The "HMAC-SHA1" signature method uses the HMAC-SHA1 signature
-    algorithm as defined in `RFC2104`_::
+    The "HMAC-SHA256" signature method uses the HMAC-SHA256 signature
+    algorithm as defined in `RFC4634`_::
 
-        digest = HMAC-SHA1 (key, text)
+        digest = HMAC-SHA256 (key, text)
 
     Per `section 3.4.2`_ of the spec.
 
-    .. _`RFC2104`: http://tools.ietf.org/html/rfc2104
+    .. _`RFC4634`: http://tools.ietf.org/html/rfc4634
     .. _`section 3.4.2`: http://tools.ietf.org/html/rfc5849#section-3.4.2
     """
 
-    # The HMAC-SHA1 function variables are used in following way:
+    # The HMAC-SHA256 function variables are used in following way:
 
     # text is set to the value of the signature base string from
     # `Section 3.4.1.1`_.

--- a/tests/oauth1/rfc5849/test_client.py
+++ b/tests/oauth1/rfc5849/test_client.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from oauthlib.common import Request
-from oauthlib.oauth1 import (SIGNATURE_PLAINTEXT, SIGNATURE_HMAC_SHA256, SIGNATURE_RSA,
+from oauthlib.oauth1 import (SIGNATURE_PLAINTEXT, SIGNATURE_HMAC_SHA1,
+                             SIGNATURE_HMAC_SHA256, SIGNATURE_RSA,
                              SIGNATURE_TYPE_BODY, SIGNATURE_TYPE_QUERY)
 from oauthlib.oauth1.rfc5849 import Client, bytes_type
 
@@ -62,13 +63,25 @@ class ClientConstructorTests(TestCase):
             self.assertIsInstance(k, bytes_type)
             self.assertIsInstance(v, bytes_type)
 
-    def test_hmac256(self):
+    def test_hmac_sha1(self):
+        client = Client('client_key')
+        # instance is using the correct signer method
+        self.assertEqual(Client.SIGNATURE_METHODS[SIGNATURE_HMAC_SHA1],
+                         client.SIGNATURE_METHODS[client.signature_method])
+
+    def test_hmac_sha256(self):
         client = Client('client_key', signature_method=SIGNATURE_HMAC_SHA256)
-        self.assertIsNone(client.rsa_key)  # don't need an RSA key to instantiate
+        # instance is using the correct signer method
+        self.assertEqual(Client.SIGNATURE_METHODS[SIGNATURE_HMAC_SHA256],
+                         client.SIGNATURE_METHODS[client.signature_method])
 
     def test_rsa(self):
         client = Client('client_key', signature_method=SIGNATURE_RSA)
-        self.assertIsNone(client.rsa_key)  # don't need an RSA key to instantiate
+        # instance is using the correct signer method
+        self.assertEqual(Client.SIGNATURE_METHODS[SIGNATURE_RSA],
+                         client.SIGNATURE_METHODS[client.signature_method])
+        # don't need an RSA key to instantiate
+        self.assertIsNone(client.rsa_key)
 
 
 class SignatureMethodTest(TestCase):


### PR DESCRIPTION
This pull incorporates changes from PR #388 as it appears orphaned.

I cleaned up the comments for the HMAC-SHA256 signing method, and added tests for the SHA1 and SHA256 signing methods (I verified the signature generation code against node's `oauth-1.0a` and `crypto` modules, to be satisfied that the test signature values were valid).